### PR TITLE
Use libattr and libacl to copy permissions if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,5 +6,13 @@ AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
 AM_PROG_CC_C_O
 AC_PROG_CXX
 
+AC_CHECK_HEADERS([attr/libattr.h attr/error_context.h])
+AC_SEARCH_LIBS(attr_copy_file, attr)
+AC_CHECK_FUNCS([attr_copy_file])
+
+AC_CHECK_HEADERS([sys/acl.h acl/libacl.h])
+AC_SEARCH_LIBS(perm_copy_file, acl)
+AC_CHECK_FUNCS([perm_copy_file])
+
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile patchelf.spec])
 AC_OUTPUT

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -17,6 +17,16 @@
 #include <fcntl.h>
 #include <limits.h>
 
+#ifdef HAVE_ATTR_LIBATTR_H
+# include <attr/libattr.h>
+#endif
+#ifdef HAVE_SYS_ACL_H
+# include <sys/acl.h>
+#endif
+#ifdef HAVE_ACL_LIBACL_H
+# include <acl/libacl.h>
+#endif
+
 #include "elf.h"
 
 using namespace std;
@@ -378,7 +388,14 @@ static void writeFile(string fileName, mode_t fileMode)
 
     if (close(fd) != 0) error("close");
 
+#if defined(HAVE_ATTR_COPY_FILE)
+    if (attr_copy_file(fileName.c_str(), fileName2.c_str(), 0, 0) != 0) error("attr_copy_file");
+#endif
+#if defined(HAVE_PERM_COPY_FILE)
+    if (perm_copy_file(fileName.c_str(), fileName2.c_str(), 0) != 0) error("perm_copy_file");
+#else
     if (chmod(fileName2.c_str(), fileMode) != 0) error("chmod");
+#endif
 
     if (rename(fileName2.c_str(), fileName.c_str()) != 0) error("rename");
 }


### PR DESCRIPTION
This is a patch we ship in the Fedora RPM. It copies ACLs and other extended attributes to the modified executable. I'm not sure you want to apply as it is, because it adds some ifdefs directly to the code, though it is fairly clean.
