### PR TITLE
Allow DT_REL without .rel.dyn or .rel.got

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -840,11 +840,18 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
                 /* no idea if this makes sense, but it was needed for some
                    program */
                 if (!shdr) shdr = findSection2(".rel.got");
-                if (!shdr) error("cannot find .rel.dyn or .rel.got");
+                /* some programs have neither section, but this doesn't seem
+                   to be a problem */
+                if (!shdr) continue;
                 dyn->d_un.d_ptr = shdr->sh_addr;
             }
-            else if (d_tag == DT_RELA)
-                dyn->d_un.d_ptr = findSection(".rela.dyn").sh_addr; /* PPC Linux */
+            else if (d_tag == DT_RELA) {
+                Elf_Shdr * shdr = findSection2(".rela.dyn");
+                /* some programs lack this section, but it doesn't seem to
+                   be a problem */
+                if (!shdr) continue;
+                dyn->d_un.d_ptr = shdr->sh_addr;
+            }
             else if (d_tag == DT_VERNEED)
                 dyn->d_un.d_ptr = findSection(".gnu.version_r").sh_addr;
             else if (d_tag == DT_VERSYM)


### PR DESCRIPTION
Some DT_REL files are missing both .rel.dyn and .rel.got. This doesn't
seem to be an error, so it shouldn't be treated as such.
