### PR TITLE
Change configure.ac from OpenWrt to support Mac OS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([patchelf], m4_esyscmd([echo -n $(cat ./version)]))
+AC_INIT([patchelf], m4_esyscmd([printf $(cat ./version)]))
 AC_CONFIG_SRCDIR([src/patchelf.cc])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests parallel-tests])


### PR DESCRIPTION
This change is from the OpenWrt project, from the URL:
https://dev.openwrt.org/ticket/18998
It enables patchelf to sucessfully compile and run under Mac OS and
keeps compatibility with Linux.

Tested under Mac OS X 10.9.5 and Ubuntu 15.04 to patch a binary of type
ELF 32-bit LSB executable - the patch fully worked

This patch is credited to Felix Fietkau