### PR TITLE
Fix converting DT_RUNPATH to DT_RPATH

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1159,8 +1159,10 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op, string newRPath)
         dynRPath = 0;
     }
 
-    if (forceRPath && dynRPath && dynRunPath) { /* convert DT_RUNPATH to DT_RPATH */
-        dynRunPath->d_tag = DT_IGNORE;
+    if (forceRPath && !dynRPath && dynRunPath) { /* convert DT_RUNPATH to DT_RPATH */
+        dynRunPath->d_tag = DT_RPATH;
+        dynRPath = dynRunPath;
+        dynRunPath = 0;
     }
 
     if (newRPath.size() <= rpathSize) {


### PR DESCRIPTION
Otherwise if I change a runpath and use `--force-rpath` it will still remain a DT_RUNPATH entry and not be converted to DT_RPATH.
