### PR TITLE
Description of `--set-soname' command

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1461,7 +1461,7 @@ void showHelp(const string & progName)
   [--set-interpreter FILENAME]\n\
   [--print-interpreter]\n\
   [--print-soname]\t\tPrints 'DT_SONAME' entry of .dynamic section. Raises an error if DT_SONAME doesn't exist\n\
-  [--set-soname SONAME]\t\tSets 'DT_SONAME' entry to SONAME. Raises an error if DT_SONAME doesn't exist\n\
+  [--set-soname SONAME]\t\tSets 'DT_SONAME' entry to SONAME.\n\
   [--set-rpath RPATH]\n\
   [--remove-rpath]\n\
   [--shrink-rpath]\n\


### PR DESCRIPTION
`--set-soname` now creates a new DT_SONAME entry if it doesn't exist.

Thinking about it, maybe there should be descriptions added to the other commands too. Or the descriptions of the soname commands should be removed in favor of updating the manpage (see PR #59).