### PR TITLE
Use location macros

### DIFF
--- a/patchelf.spec.in
+++ b/patchelf.spec.in
@@ -27,12 +27,12 @@ make check
 %install
 rm -rf $RPM_BUILD_ROOT
 make DESTDIR=$RPM_BUILD_ROOT install
-strip $RPM_BUILD_ROOT/%{_prefix}/bin/* || true
+# rpmbuild automatically strips... strip $RPM_BUILD_ROOT/%{_bindir}/* || true
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %files
-/usr/bin/patchelf
-/usr/share/doc/patchelf/README
-/usr/share/man/man1/patchelf.1.gz
+%{_bindir}/patchelf
+%doc %{_docdir}/patchelf/README
+%{_mandir}/man1/patchelf.1.gz

--- a/patchelf.spec.in
+++ b/patchelf.spec.in
@@ -6,8 +6,8 @@ Release: 1
 License: GPL
 Group: Development/Tools
 URL: http://nixos.org/patchelf.html
-Source0: %{name}-@PACKAGE_VERSION@.tar.bz2
-BuildRoot: %{_tmppath}/%{name}-%{PACKAGE_VERSION}-buildroot
+Source0: %{name}-%{version}.tar.bz2
+BuildRoot: %{_tmppath}/%{name}-%{version}-buildroot
 Prefix: /usr
 
 %description
@@ -27,7 +27,7 @@ make check
 %install
 rm -rf $RPM_BUILD_ROOT
 make DESTDIR=$RPM_BUILD_ROOT install
-# rpmbuild automatically strips... strip $RPM_BUILD_ROOT/%{_bindir}/* || true
+# rpmbuild automatically strips... strip $RPM_BUILD_ROOT/%%{_bindir}/* || true
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Fixes %files bug when prefix is not "/usr"

See also: https://fedoraproject.org/wiki/Packaging:RPMMacros