### PR TITLE
--show-needed option

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1566,6 +1566,7 @@ int main(int argc, char * * argv)
     fileName = argv[i];
 
     patchElf();
+    if (contents) free(contents);
 
     return 0;
 }


### PR DESCRIPTION
To complement the add/remove/replace options of `DT_NEEDED` entries. 

Otherwise I was doing things with `readelf` and `grep`.

I am not an ELF expert in any way, so if this was already possible with some of the other options, please advise.
