### PR TITLE
Remaining sing-compare warnings

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -627,7 +627,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
     /* Write out the replaced sections. */
     Elf_Off curOff = startOffset + phdrs.size() * sizeof(Elf_Phdr);
     writeReplacedSections(curOff, startPage, startOffset);
-    assert((off_t) curOff == startOffset + neededSpace);
+    assert(curOff == startOffset + neededSpace);
 
 
     /* Move the program header to the start of the new area. */
@@ -696,7 +696,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsExecutable()
     Elf_Addr firstPage = startAddr - startOffset;
     debug("first page is 0x%llx\n", (unsigned long long) firstPage);
 
-    if ((off_t) rdi(hdr->e_shoff) < startOffset) {
+    if (rdi(hdr->e_shoff) < startOffset) {
         /* The section headers occur too early in the file and would be
            overwritten by the replaced sections. Move them to the end of the file
            before proceeding. */
@@ -752,7 +752,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsExecutable()
 
     /* Write out the replaced sections. */
     writeReplacedSections(curOff, firstPage, 0);
-    assert((off_t) curOff == neededSpace);
+    assert(curOff == neededSpace);
 
 
     rewriteHeaders(firstPage + rdi(hdr->e_phoff));


### PR DESCRIPTION
Get rid of remaining sing-compare warnings that appear when using gcc 5.2.

```
In file included from patchelf.cc:10:0:
patchelf.cc: In instantiation of 'void ElfFile<Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym>::rewriteSectionsLibrary() [with Elf_Ehdr = Elf64_Ehdr; Elf_Phdr = Elf64_Phdr; Elf_Shdr = Elf64_Shdr; Elf_Addr = long unsigned int; Elf_Off = long unsigned int; Elf_Dyn = Elf64_Dyn; Elf_Sym = Elf64_Sym]':
patchelf.cc:774:31:   required from 'void ElfFile<Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym>::rewriteSections() [with Elf_Ehdr = Elf64_Ehdr; Elf_Phdr = Elf64_Phdr; Elf_Shdr = Elf64_Shdr; Elf_Addr = long unsigned int; Elf_Off = long unsigned int; Elf_Dyn = Elf64_Dyn; Elf_Sym = Elf64_Sym]'
patchelf.cc:1416:9:   required from 'void patchElf2(ElfFile&, mode_t) [with ElfFile = ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, long unsigned int, long unsigned int, Elf64_Dyn, Elf64_Sym>; mode_t = unsigned int]'
patchelf.cc:1450:36:   required from here
patchelf.cc:630:27: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     assert((off_t) curOff == startOffset + neededSpace);
                           ^
patchelf.cc: In instantiation of 'void ElfFile<Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym>::rewriteSectionsExecutable() [with Elf_Ehdr = Elf64_Ehdr; Elf_Phdr = Elf64_Phdr; Elf_Shdr = Elf64_Shdr; Elf_Addr = long unsigned int; Elf_Off = long unsigned int; Elf_Dyn = Elf64_Dyn; Elf_Sym = Elf64_Sym]':
patchelf.cc:777:34:   required from 'void ElfFile<Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym>::rewriteSections() [with Elf_Ehdr = Elf64_Ehdr; Elf_Phdr = Elf64_Phdr; Elf_Shdr = Elf64_Shdr; Elf_Addr = long unsigned int; Elf_Off = long unsigned int; Elf_Dyn = Elf64_Dyn; Elf_Sym = Elf64_Sym]'
patchelf.cc:1416:9:   required from 'void patchElf2(ElfFile&, mode_t) [with ElfFile = ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, long unsigned int, long unsigned int, Elf64_Dyn, Elf64_Sym>; mode_t = unsigned int]'
patchelf.cc:1450:36:   required from here
patchelf.cc:699:35: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if ((off_t) rdi(hdr->e_shoff) < startOffset) {
                                   ^
In file included from patchelf.cc:10:0:
patchelf.cc:755:27: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     assert((off_t) curOff == neededSpace);
                           ^
```