### PR TITLE
Allow specifying pagesize

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,5 +6,23 @@ AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
 AM_PROG_CC_C_O
 AC_PROG_CXX
 
+PAGESIZE=auto
+AC_ARG_WITH([page-size],
+	    AS_HELP_STRING([--with-page-size=SIZE], [Specify default pagesize (default auto)]),
+	    PAGESIZE=$withval
+	    )
+
+AS_IF([test "x$PAGESIZE" = xauto],
+	AS_IF([which getconf &>/dev/null], [
+	       PAGESIZE=`getconf PAGESIZE &>/dev/null || getconf PAGE_SIZE &>/dev/null`
+	])
+	AS_IF([test "x$PAGESIZE" = x], [
+	       PAGESIZE=4096
+	])
+)
+
+AC_DEFINE_UNQUOTED(PAGESIZE, ${PAGESIZE})
+AC_MSG_RESULT([Setting page size to ${PAGESIZE}])
+
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile patchelf.spec])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,5 @@ AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
 AM_PROG_CC_C_O
 AC_PROG_CXX
 
-AC_CHECK_FUNCS([sysconf])
-
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile patchelf.spec])
 AC_OUTPUT

--- a/patchelf.1
+++ b/patchelf.1
@@ -22,6 +22,9 @@ of executables and change the RPATH of executables and libraries.
 
 The single option given operates on a given FILE, editing in place.
 
+.IP "--page-size SIZE"
+Uses the given page size instead of the default.
+
 .IP "--set-interpreter INTERPRETER"
 Change the dynamic loader ("ELF interpreter") of executable given to
 INTERPRETER.

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -40,13 +40,7 @@ unsigned char * contents = 0;
 
 
 static unsigned int getPageSize(){
-#ifdef MIPSEL
-    /* The lemote fuloong 2f kernel defconfig sets a page size of
-       16KB. */
-    return 4096 * 4;
-#else
-    return 4096;
-#endif
+    return PAGESIZE;
 }
 
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -29,7 +29,7 @@ static bool debugMode = false;
 static bool forceRPath = false;
 
 static string fileName;
-
+static int pageSize = PAGESIZE;
 
 off_t fileSize, maxSize;
 unsigned char * contents = 0;
@@ -40,7 +40,7 @@ unsigned char * contents = 0;
 
 
 static unsigned int getPageSize(){
-    return PAGESIZE;
+    return pageSize;
 }
 
 
@@ -1472,6 +1472,7 @@ void showHelp(const string & progName)
 {
         fprintf(stderr, "syntax: %s\n\
   [--set-interpreter FILENAME]\n\
+  [--page-size SIZE]\n\
   [--print-interpreter]\n\
   [--print-soname]\t\tPrints 'DT_SONAME' entry of .dynamic section. Raises an error if DT_SONAME doesn't exist\n\
   [--set-soname SONAME]\t\tSets 'DT_SONAME' entry to SONAME.\n\
@@ -1507,6 +1508,11 @@ int main(int argc, char * * argv)
             if (++i == argc) error("missing argument");
             newInterpreter = argv[i];
         }
+        else if (arg == "--page-size") {
+            if (++i == argc) error("missing argument");
+            pageSize = atoi(argv[i]);
+            if (pageSize <= 0) error("invalid argument to --page-size");
+	}
         else if (arg == "--print-interpreter") {
             printInterpreter = true;
         }


### PR DESCRIPTION
This PR uses getconf to select the default pagesize (with a fallback to 4096). It also adds an option to specify the pagesize at runtime to operate on foreign binaries.

This is more of a RFC and call for tests, so please test!

/cc @adevress @domenkozar 