### PR TITLE
rewriteHeaders(): Don't assume PT_PHDR is the first program header

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -787,11 +787,14 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
     /* Rewrite the program header table. */
 
     /* If there is a segment for the program header table, update it.
-       (According to the ELF spec, it must be the first entry.) */
-    if (rdi(phdrs[0].p_type) == PT_PHDR) {
-        phdrs[0].p_offset = hdr->e_phoff;
-        wri(phdrs[0].p_vaddr, wri(phdrs[0].p_paddr, phdrAddress));
-        wri(phdrs[0].p_filesz, wri(phdrs[0].p_memsz, phdrs.size() * sizeof(Elf_Phdr)));
+       (According to the ELF spec, there can only be one.) */
+    for (unsigned int i = 0; i < phdrs.size(); ++i) {
+        if (rdi(phdrs[i].p_type) == PT_PHDR) {
+            phdrs[i].p_offset = hdr->e_phoff;
+            wri(phdrs[i].p_vaddr, wri(phdrs[i].p_paddr, phdrAddress));
+            wri(phdrs[i].p_filesz, wri(phdrs[i].p_memsz, phdrs.size() * sizeof(Elf_Phdr)));
+            break;
+        }
     }
 
     sortPhdrs();


### PR DESCRIPTION
Because this assumption doesn't seem to be valid either in theory or
practice: the spec (http://refspecs.linuxbase.org/elf/elf.pdf) only
places these requirements on PT_PHDR:

"This segment type may not occur more than once in a file. Moreover,
it may occur only if the program header table is part of the memory
image of the program. If it is present, it must precede any loadable
segment entry."

And on ARM, binaries generated by GNU GCC / binutils almost never have
PT_PHDR as the first entry, e.g. the coreutils 'ls' has this:

````
Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  EXIDX          0x0169b4 0x0001e9b4 0x0001e9b4 0x00008 0x00008 R   0x4
  PHDR           0x000034 0x00008034 0x00008034 0x00120 0x00120 R E 0x4
  INTERP         0x000154 0x00008154 0x00008154 0x0004f 0x0004f R   0x1
      [Requesting program interpreter: /nix/store/whcad4dnkp5pnhbv4p0f9k8srv0kmcjk-glibc-2.21/lib/ld-linux-armhf.so.3]
  LOAD           0x000000 0x00008000 0x00008000 0x169c0 0x169c0 R E 0x8000
  LOAD           0x0169c0 0x000269c0 0x000269c0 0x003f4 0x01088 RW  0x8000
  DYNAMIC        0x0169cc 0x000269cc 0x000269cc 0x000f8 0x000f8 RW  0x4
  NOTE           0x0001a4 0x000081a4 0x000081a4 0x00020 0x00020 R   0x4
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0x4
  PAX_FLAGS      0x000000 0x00000000 0x00000000 0x00000 0x00000     0x4
````

This problem has existed for quite a long time on ARM and often results
in patchelf'd programs segfaulting inside the glibc dynamic linker,
which relies on PT_PHDR containing valid contents. This has been worked
around in Nixpkgs in various creative ways, like:

https://github.com/NixOS/nixpkgs/blob/5c20877d40726b6973d222f71fa6e306428c19cf/nixos/modules/system/boot/stage-1.nix#L109

Applying patchelf twice did actually work in practice due to the fact
that patchelf sorts the program headers, causing the first round
of patchelf to rewrite an invalid PT_PHDR to appear first, and then
the second round of patchelf fixing that PT_PHDR.