### PR TITLE
add --shrink-prefix used for build while package is not installed

### DIFF
--- a/patchelf.1
+++ b/patchelf.1
@@ -53,6 +53,9 @@ For instance, if an executable references one library libfoo.so, has
 an RPATH "/lib:/usr/lib:/foo/lib", and libfoo.so can only be found
 in /foo/lib, then the new RPATH will be "/foo/lib".
 
+.IP --shrink-prefix
+Work with --shrink-rpath, used in stage of build before installed to real dest path.
+
 .IP --print-rpath
 Prints the RPATH for an executable or library.
 


### PR DESCRIPTION
FIX #100.

In addition, the '--shrink-prefix' option can be used for specify rpath
when executable is building in anothen buildroot. For instance, if an
executable located in /tmp/buildroot and can only be installed to
/usr/local. To accomplish that in build stage, use:

$ patchelf --shrink-rpath --shrink-prefix /tmp/buildroot