### PR TITLE
tests: Do not exit on an expected failure code.

### DIFF
--- a/tests/set-rpath-library.sh
+++ b/tests/set-rpath-library.sh
@@ -26,7 +26,6 @@ exitCode=0
 
 if test "$exitCode" = 46; then
     echo "expected failure"
-    exit 1
 fi
 
 # So set an RUNPATH on libfoo as well.


### PR DESCRIPTION
The comment in the code below the patched line
clearly suggests that it should go on in this case.
This condition occurs on Alpine Linux (musl-libc-based):
http://patchwork.alpinelinux.org/patch/2206/
