### PR TITLE
emit an error if multiple target files are given

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1736,6 +1736,7 @@ int mainWrapped(int argc, char * * argv)
     }
 
     if (i == argc) error("missing filename");
+    if (i + 1 < argc) error("only one target filename permitted");
     fileName = argv[i];
 
     patchElf();


### PR DESCRIPTION
Only one file may be patched at a time. patchelf previously silently ignored extra command line arguments. Make extra arguments be an error.
