### PR TITLE
Add travis configuration to run CI on github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+dist: trusty
+sudo: false
+script:
+  - ./bootstrap.sh && ./configure && make && make check
+compiler:
+  - clang
+  - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
 dist: trusty
 sudo: false
+notifications:
+  email: false
 script:
   - ./bootstrap.sh && ./configure && make && make check
 compiler:


### PR DESCRIPTION
This travis CI configuration will automatically build and run the test suite of patchelf whenever a commit or pull request is made on Github. It uses the `trusty` container-based configuration to deploy patchelf and build it on an Ubuntu 14.04 container, since the version of autoconf required by patchelf is newer than that provided by the `precise` containers.

To enable travis on a github repository, go to https://travis-ci.org, login with Github and flip the switch for the `NixOS/patchelf` repository.  Here's the [getting started guide](https://docs.travis-ci.com/user/getting-started/) in case you have any questions.

I tested this configuration out on my own fork, you can see the result of [this PR here](https://travis-ci.org/staticfloat/patchelf/builds/190118634).