### PR TITLE
always define PACKAGE_STRING and PAGESIZE

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -40,6 +40,14 @@
 #include "elf.h"
 
 
+#ifndef PACKAGE_STRING
+#define PACKAGE_STRING "patchelf"
+#endif
+#ifndef PAGESIZE
+#define PAGESIZE 4096
+#endif
+
+
 static bool debugMode = false;
 
 static bool forceRPath = false;


### PR DESCRIPTION
This way you can compile the program in a simple one-liner. That can always come in handy.