### PR TITLE
Better error messages when run on statically-linked (or otherwise weird) binaries

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -392,10 +392,13 @@ ElfFile<ElfFileParamNames>::ElfFile(FileContents fileContents)
         error("wrong ELF type");
 
     if ((size_t) (rdi(hdr->e_phoff) + rdi(hdr->e_phnum) * rdi(hdr->e_phentsize)) > fileContents->size())
-        error("missing program headers");
+        error("program header table out of bounds");
+
+    if (rdi(hdr->e_shnum) == 0)
+        error("no section headers. The input file is probably a statically linked, self-decompressing binary");
 
     if ((size_t) (rdi(hdr->e_shoff) + rdi(hdr->e_shnum) * rdi(hdr->e_shentsize)) > fileContents->size())
-        error("missing section headers");
+        error("section header table out of bounds");
 
     if (rdi(hdr->e_phentsize) != sizeof(Elf_Phdr))
         error("program headers have wrong size");

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -557,8 +557,12 @@ template<ElfFileParams>
 Elf_Shdr & ElfFile<ElfFileParamNames>::findSection(const SectionName & sectionName)
 {
     Elf_Shdr * shdr = findSection2(sectionName);
-    if (!shdr)
-        error("cannot find section '" + sectionName + "'");
+    if (!shdr) {
+        std::string extraMsg = "";
+        if (sectionName == ".interp" || sectionName == ".dynamic" || sectionName == ".dynstr")
+            extraMsg = ". The input file is most likely statically linked";
+        error("cannot find section '" + sectionName + "'" + extraMsg);
+    }
     return *shdr;
 }
 


### PR DESCRIPTION
Make patchelf give nicer error messages. In particular, some UPX-compressed files in the wild have no section header table at all, which currently prints a `Assertion 'shstrtabIndex < shdrs.size()' failed.` message.