### PR TITLE
fix adjusting startPage

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -720,10 +720,8 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
        since DYN executables tend to start at virtual address 0, so
        rewriteSectionsExecutable() won't work because it doesn't have
        any virtual address space to grow downwards into. */
-    if (isExecutable) {
-        if (startOffset >= startPage) {
-            debug("shifting new PT_LOAD segment by %d bytes to work around a Linux kernel bug\n", startOffset - startPage);
-        }
+    if (isExecutable && startOffset > startPage) {
+        debug("shifting new PT_LOAD segment by %d bytes to work around a Linux kernel bug\n", startOffset - startPage);
         startPage = startOffset;
     }
 


### PR DESCRIPTION
startPage is adjusted unconditionally for all executables.
This results in incorrect addresses assigned to INTERP and LOAD
program headers, which breaks patched executable.

Adjusting startPage variable only when startOffset > startPage
should fix this.

This change is related to the issue NixOS#10

Signed-off-by: Ed Bartosh <ed.bartosh@linux.intel.com>