### PR TITLE
Fixed parallel execution of tests (parallel-tests in automake)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,8 @@
+AC_PREREQ([2.62])
 AC_INIT([patchelf], m4_esyscmd([printf $(cat ./version)]))
 AC_CONFIG_SRCDIR([src/patchelf.cc])
 AC_CONFIG_AUX_DIR([build-aux])
-AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
+AM_INIT_AUTOMAKE([1.11.1 -Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
 
 AM_PROG_CC_C_O
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT([patchelf], m4_esyscmd([printf $(cat ./version)]))
 AC_CONFIG_SRCDIR([src/patchelf.cc])
 AC_CONFIG_AUX_DIR([build-aux])
-AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests serial-tests])
+AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
 
 AM_PROG_CC_C_O
 AC_PROG_CXX

--- a/tests/no-rpath-prebuild.sh
+++ b/tests/no-rpath-prebuild.sh
@@ -4,7 +4,7 @@ ARCH="$1"
 PAGESIZE=4096
 
 if [ -z "$ARCH" ]; then
-  ARCH=$(basename $0 .sh | sed -e 's/.*-//')
+  ARCH=$(basename $0 .sh | sed -e 's/^no-rpath-//')
 fi
 
 SCRATCH=scratch/no-rpath-$ARCH


### PR DESCRIPTION
The first commit fixes rollback to serial-tests (introduced in https://github.com/NixOS/patchelf/commit/4034c6de0bde16c6a614b78df4d5aa39b2e3c21f), the second one sets appropriate version of **automake** to understand _parallel-tests_ option (introduced in 1.11.1) and **autoconf** version to be able to work with **automake 1.11.1.**
This patch also fixes https://github.com/NixOS/patchelf/issues/126 and https://github.com/NixOS/patchelf/issues/112.