### PR TITLE
Don't throw an error on missing DT_JMPREL section

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -942,7 +942,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
                 Elf_Shdr * shdr = findSection2(".rel.plt");
                 if (!shdr) shdr = findSection2(".rela.plt"); /* 64-bit Linux, x86-64 */
                 if (!shdr) shdr = findSection2(".rela.IA_64.pltoff"); /* 64-bit Linux, IA-64 */
-                if (!shdr) error("cannot find section corresponding to DT_JMPREL");
+                if (!shdr) continue;		
                 dyn->d_un.d_ptr = shdr->sh_addr;
             }
             else if (d_tag == DT_REL) { /* !!! hack! */


### PR DESCRIPTION
Excelsior JET (excelsiorjet.com) generates executables that don't have a section that corresponds to DT_JMPREL. It is impossible to patch such executables before this patch and after this patch these executables work fine (with interpreter set to NixOS dynamic linker).