### PR TITLE
Bugfix for CompPhdr::operator() that could cause sort to fail.

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -135,7 +135,10 @@ private:
         ElfFile * elfFile;
         bool operator ()(const Elf_Phdr & x, const Elf_Phdr & y)
         {
-            if (x.p_type == PT_PHDR) return true;
+            if (x.p_type == PT_PHDR) {
+                  if (y.p_type == PT_PHDR) return false;
+                  return true;
+            }
             if (y.p_type == PT_PHDR) return false;
             return elfFile->rdi(x.p_paddr) < elfFile->rdi(y.p_paddr);
         }

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -135,12 +135,12 @@ private:
         ElfFile * elfFile;
         bool operator ()(const Elf_Phdr & x, const Elf_Phdr & y)
         {
-            if (x.p_type == PT_PHDR) {
-                  if (y.p_type == PT_PHDR) return false;
-                  return true;
-            }
-            if (y.p_type == PT_PHDR) return false;
-            return elfFile->rdi(x.p_paddr) < elfFile->rdi(y.p_paddr);
+          // A PHDR comes before everything else.
+          if (y.p_type == PT_PHDR) return false;
+          if (x.p_type == PT_PHDR) return true;
+
+          // Sort non-PHDRs by address.
+          return elfFile->rdi(x.p_paddr) < elfFile->rdi(y.p_paddr);
         }
     };
 


### PR DESCRIPTION
Modified CompPhdr::operator() so that it provides a strict weak ordering as required by std::sort.