### PR TITLE
Add CentOS 7.4 to release RPM builds

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -44,6 +44,8 @@ let
         isReproducible = system != "aarch64-linux"; # ARM machines are still on Nix 1.11
       });
 
+    rpm_centos73x86_64 = makeRPM_x86_64 (diskImages: diskImages.centos73x86_64);
+    rpm_centos74x86_64 = makeRPM_x86_64 (diskImages: diskImages.centos74x86_64);
 
     rpm_fedora24i386 = makeRPM_i686 (diskImages: diskImages.fedora24i386);
     rpm_fedora24x86_64 = makeRPM_x86_64 (diskImages: diskImages.fedora24x86_64);
@@ -72,6 +74,7 @@ let
             #build.x86_64-freebsd
             #build.i686-freebsd
             #build.x86_64-darwin
+            rpm_centos74x86_64
             rpm_fedora25i386
             rpm_fedora25x86_64
             deb_debian8i386


### PR DESCRIPTION
This provides RPMs for CentOS 7.4 users, and their counterparts on the
enterprise release RHEL 7.4.

Since CentOS/RHEL 7.4 are based off gcc 4.8.x, they do not have a compliant `c++14` compiler available by default for building RPMs.  Patchelf does not currently require this and builds fine, but it's worth noting that merging this PR will ensure that that remains the case until the next CentOS/RHEL versions are released.