### PR TITLE
Mention --set-soname in README

### DIFF
--- a/README
+++ b/README
@@ -47,6 +47,10 @@ libraries.  In particular, it can do the following:
 
   This option can be give multiple times.
 
+* Change SONAME of a dynamic library:
+
+  $ patchelf --set-soname libnewname.so.3.4.5 path/to/libmylibrary.so.1.2.3
+  
 
 INSTALLING
 


### PR DESCRIPTION
Changing shared library SONAME is not a usual task and patchelf may be the only utility that can do it. As README does not mention this feature at all, one can easily miss it when searching for a suitable tool.