### PR TITLE
Fix issue #66: ignore 0th section header when sorting, don't overwrite NOBITS

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -475,7 +475,7 @@ void ElfFile<ElfFileParamNames>::sortShdrs()
     /* Sort the sections by offset. */
     CompShdr comp;
     comp.elfFile = this;
-    sort(shdrs.begin(), shdrs.end(), comp);
+    sort(shdrs.begin() + 1, shdrs.end(), comp);
 
     /* Restore the sh_link mappings. */
     for (unsigned int i = 1; i < rdi(hdr->e_shnum); ++i)
@@ -642,7 +642,8 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
     for (auto & i : replacedSections) {
         std::string sectionName = i.first;
         Elf_Shdr & shdr = findSection(sectionName);
-        memset(contents + rdi(shdr.sh_offset), 'X', rdi(shdr.sh_size));
+        if (shdr.sh_type != SHT_NOBITS)
+            memset(contents + rdi(shdr.sh_offset), 'X', rdi(shdr.sh_size));
     }
 
     for (auto & i : replacedSections) {


### PR DESCRIPTION
To recount the problem symptoms: Given an executable with certain properties, including a section at offset 0, patchelf fails to set the interpreter. (With patchelf 0.8 you get an assertion failure, (off_t) rdi(hdr->e_shoff) >= startOffset'. With patchelf 0.9 you get cannot find section, which is referring to the section with the empty name, which is some kind of dummy placeholder in ELF files, at section index 0.)

Here's my understanding of the bug: Most of the code in patchelf ignores the 0th entry in the section header table, but there is a call to C++ `sort()` which can move the entry at index 0, in the case where some other entry also has offset 0 (which is the case for Go binaries, a .tbss section has offset 0). It is easy to skip entry 0 in the sort. Then another problem kicks in, which is that patchelf tries to overwrite some bytes (with 'X's) at that offset 0, even though the `.tbss` section is marked as NOBITS and thus has no content.