### PR TITLE
Fix #150 - Check ELF endianness before writing new runpath

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1269,13 +1269,13 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
     debug("new rpath is '%s'\n", newRPath.c_str());
 
     if (!forceRPath && dynRPath && !dynRunPath) { /* convert DT_RPATH to DT_RUNPATH */
-        dynRPath->d_tag = DT_RUNPATH;
+        wri(dynRPath->d_tag, DT_RUNPATH);
         dynRunPath = dynRPath;
         dynRPath = 0;
     }
 
     if (forceRPath && dynRPath && dynRunPath) { /* convert DT_RUNPATH to DT_RPATH */
-        dynRunPath->d_tag = DT_IGNORE;
+        wri(dynRPath->d_tag, DT_RUNPATH);
     }
 
     if (newRPath.size() <= rpathSize) {


### PR DESCRIPTION
This pull request makes a change to the way the RUNPATH field is updated in the dynamic section. Currently, patchelf does not take into account the target architecture of the ELF file before doing this (when --make-rpath-relative is specified).  Thus, the elf file ends up having an invalid tag for RUNPATH if the endianness differs. (0x1d000000 instead of 0x0000001d). 

The change proposed here updates the way these fields are written using the already defined endian-safe functions.  Tested on both PowerPC and ARM targets with a x86_64 host.