### PR TITLE
Overwrite soname in place if there is room

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1082,6 +1082,15 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
 
     debug("new SONAME is '%s'\n", newSoname.c_str());
 
+    /* If new SONAME fits in existing space, overwrite. This works around
+       issue #44. */
+    if (newSoname.size() <= sonameSize) {
+       debug("overwriting old SONAME with new...\n");
+       strcpy(soname, newSoname.c_str());
+       changed = true;
+       return;
+    }
+
     /* Grow the .dynstr section to make room for the new SONAME. */
     debug("SONAME is too long, resizing...\n");
 


### PR DESCRIPTION
This addresses issue #44 for the case where the new soname is the same or shorter than the old.

It's not great code. I'm not a C++ programmer, and I couldn't figure out how to make the overwrite idiomatic. So, it uses C string functions.

But, it does work for us.