### PR TITLE
Remove zeroing out logic in modifySoname

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1074,13 +1074,6 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
         return;
     }
 
-    /* Zero out the previous SONAME */
-    unsigned int sonameSize = 0;
-    if (soname) {
-        sonameSize = strlen(soname);
-        memset(soname, 'X', sonameSize);
-    }
-
     debug("new SONAME is '%s'\n", newSoname.c_str());
 
     /* Grow the .dynstr section to make room for the new SONAME. */


### PR DESCRIPTION
The original SONAME is filled with 'X' characters in the modifySoname
function. This can cause issues if the .dynstr entry is still referenced
in other sections, e.g. some libraries use the SONAME entry as version
specifiers.

Closes: #155 