### PR TITLE
Fixes for MIPS binaries

### DIFF
--- a/src/elf.h
+++ b/src/elf.h
@@ -1574,9 +1574,10 @@ typedef struct
 
 /* Legal values for p_type field of Elf32_Phdr.  */
 
-#define PT_MIPS_REGINFO	0x70000000	/* Register usage information */
-#define PT_MIPS_RTPROC  0x70000001	/* Runtime procedure table. */
-#define PT_MIPS_OPTIONS 0x70000002
+#define PT_MIPS_REGINFO	  0x70000000	/* Register usage information. */
+#define PT_MIPS_RTPROC	  0x70000001	/* Runtime procedure table. */
+#define PT_MIPS_OPTIONS	  0x70000002
+#define PT_MIPS_ABIFLAGS  0x70000003	/* FP mode requirement. */
 
 /* Special program header types.  */
 

--- a/src/elf.h
+++ b/src/elf.h
@@ -1642,7 +1642,11 @@ typedef struct
    PLT is writable.  For a non-writable PLT, this is omitted or has a zero
    value.  */
 #define DT_MIPS_RWPLT        0x70000034
-#define DT_MIPS_NUM	     0x35
+/* An alternative description of the classic MIPS RLD_MAP that is usable
+   in a PIE as it stores a relative offset from the address of the tag
+   rather than an absolute address.  */
+#define DT_MIPS_RLD_MAP_REL  0x70000035
+#define DT_MIPS_NUM          0x36
 
 /* Legal values for DT_MIPS_FLAGS Elf32_Dyn entry.  */
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -766,6 +766,18 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
                 }
         }
 
+        /* If there is .MIPS.abiflags section, then the PT_MIPS_ABIFLAGS
+           segment must be sync'ed with it. */
+        if (sectionName == ".MIPS.abiflags") {
+            for (auto & phdr : phdrs) {
+                if (rdi(phdr.p_type) == PT_MIPS_ABIFLAGS) {
+                    phdr.p_offset = shdr.sh_offset;
+                    phdr.p_vaddr = phdr.p_paddr = shdr.sh_addr;
+                    phdr.p_filesz = phdr.p_memsz = shdr.sh_size;
+                }
+            }
+        }
+
         curOff += roundUp(i.second.size(), sectionAlignment);
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,6 +22,7 @@ src_TESTS = \
   plain-fail.sh plain-run.sh shrink-rpath.sh set-interpreter-short.sh \
   set-interpreter-long.sh set-rpath.sh add-rpath.sh no-rpath.sh big-dynstr.sh \
   set-rpath-library.sh soname.sh shrink-rpath-with-allowed-prefixes.sh \
+  set-rpath-rel-map.sh \
   force-rpath.sh \
   plain-needed.sh \
   output-flag.sh \

--- a/tests/set-rpath-rel-map.sh
+++ b/tests/set-rpath-rel-map.sh
@@ -1,0 +1,37 @@
+#! /bin/sh -e
+
+if ! objdump -p main | grep -q MIPS_RLD_MAP_REL; then
+    echo "No MIPS_RLD_MAP_REL dynamic section entry, skipping"
+    exit 0
+fi
+
+SCRATCH=scratch/$(basename $0 .sh)
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+mkdir -p ${SCRATCH}/libsA
+mkdir -p ${SCRATCH}/libsB
+
+cp main ${SCRATCH}/
+cp libfoo.so ${SCRATCH}/libsA/
+cp libbar.so ${SCRATCH}/libsB/
+
+# break the main executable by removing .rld_map section
+objcopy --remove-section .rld_map ${SCRATCH}/main
+
+oldRPath=$(../src/patchelf --print-rpath ${SCRATCH}/main)
+if test -z "$oldRPath"; then oldRPath="/oops"; fi
+../src/patchelf --force-rpath --set-rpath $oldRPath:$(pwd)/${SCRATCH}/libsA:$(pwd)/${SCRATCH}/libsB ${SCRATCH}/main
+
+if test "$(uname)" = FreeBSD; then
+    export LD_LIBRARY_PATH=$(pwd)/${SCRATCH}/libsB
+fi
+
+exitCode=0
+
+(cd ${SCRATCH} && ./main) || exitCode=$?
+
+if test "$exitCode" != 46; then
+    echo "bad exit code!"
+    exit 1
+fi


### PR DESCRIPTION
A couple of changes that address problems described in #82.

Tested on two machines, Baikal BE-T1000 and Loongson 3A, running mipsel port of ALT Linux Sisyphus. With these two changes, all tests pass on both of the machines, and on my x86_64 machine.