### PR TITLE
Added --output flag

### DIFF
--- a/patchelf.1
+++ b/patchelf.1
@@ -83,6 +83,9 @@ option can be given multiple times.
 Marks the object that the search for dependencies of this object will ignore any
 default library search paths.
 
+.IP "--output FILE"
+Set the output file name.  If not specified, the input will be modified in place.
+
 .IP --debug
 Prints details of the changes made to the input file.
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,7 +21,8 @@ no_rpath_arch_TESTS = \
 src_TESTS = \
   plain-fail.sh plain-run.sh shrink-rpath.sh set-interpreter-short.sh \
   set-interpreter-long.sh set-rpath.sh no-rpath.sh big-dynstr.sh \
-  set-rpath-library.sh soname.sh shrink-rpath-with-allowed-prefixes.sh
+  set-rpath-library.sh soname.sh shrink-rpath-with-allowed-prefixes.sh \
+  output-flag.sh
 
 build_TESTS = \
   $(no_rpath_arch_TESTS)

--- a/tests/output-flag.sh
+++ b/tests/output-flag.sh
@@ -1,0 +1,38 @@
+#! /bin/sh -e
+SCRATCH=scratch/$(basename $0 .sh)
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+mkdir -p ${SCRATCH}/libsA
+mkdir -p ${SCRATCH}/libsB
+
+cp main ${SCRATCH}/
+cp libfoo.so ${SCRATCH}/libsA/
+cp libbar.so ${SCRATCH}/libsB/
+
+oldRPath=$(../src/patchelf --print-rpath ${SCRATCH}/main)
+if test -z "$oldRPath"; then oldRPath="/oops"; fi
+
+../src/patchelf --force-rpath --set-rpath $oldRPath:$(pwd)/${SCRATCH}/libsA:$(pwd)/${SCRATCH}/libsB ${SCRATCH}/main --output ${SCRATCH}/main2
+# make sure it copies even when there is nothing to do (because rpath is already set)
+../src/patchelf --force-rpath --set-rpath $oldRPath:$(pwd)/${SCRATCH}/libsA:$(pwd)/${SCRATCH}/libsB ${SCRATCH}/main2 --output ${SCRATCH}/main3
+
+if test "$(uname)" = FreeBSD; then
+    export LD_LIBRARY_PATH=$(pwd)/${SCRATCH}/libsB
+fi
+
+exitCode=0
+(cd ${SCRATCH} && ./main2) || exitCode=$?
+
+if test "$exitCode" != 46; then
+    echo "bad exit code!"
+    exit 1
+fi
+
+exitCode=0
+(cd ${SCRATCH} && ./main3) || exitCode=$?
+
+if test "$exitCode" != 46; then
+    echo "bad exit code!"
+    exit 1
+fi


### PR DESCRIPTION
This flag allows the output to be different from the input.  This can be used during `make install` to avoid an unnecessary cp command.  That can save a lot of disk I/O for large projects.