### PR TITLE
allow overriding systems

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,7 @@
 { patchelfSrc ? { outPath = ./.; revCount = 1234; shortRev = "abcdef"; }
 , nixpkgs ? builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-20.03.tar.gz
 , officialRelease ? false
+, systems ? [ "x86_64-linux" "i686-linux" "aarch64-linux" /* "x86_64-freebsd" "i686-freebsd"  "x86_64-darwin" "i686-solaris" "i686-cygwin" */ ]
 }:
 
 let
@@ -39,7 +40,7 @@ let
       };
 
 
-    build = pkgs.lib.genAttrs [ "x86_64-linux" "i686-linux" "aarch64-linux" /* "x86_64-freebsd" "i686-freebsd"  "x86_64-darwin" "i686-solaris" "i686-cygwin" */ ] (system:
+    build = pkgs.lib.genAttrs systems (system:
 
       with import nixpkgs { inherit system; };
 


### PR DESCRIPTION
This allows skipping the aarch64 build on x86-only hydra instances.

Note: I copied the systems list with all commented systems.

In the nix release.nix the parameter is called "systems", in the nixpkgs nixos/release.nix it is called "supportedSystems". I went with "systems" but can also change it.