### PR TITLE
Some const-correctness and C++11 auto

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -165,7 +165,7 @@ private:
 
     void shiftFile(unsigned int extraPages, Elf_Addr startPage);
 
-    std::string getSectionName(const Elf_Shdr & shdr);
+    std::string getSectionName(const Elf_Shdr & shdr) const;
 
     Elf_Shdr & findSection(const SectionName & sectionName);
 
@@ -176,7 +176,7 @@ private:
     std::string & replaceSection(const SectionName & sectionName,
         unsigned int size);
 
-    bool haveReplacedSection(const SectionName & sectionName);
+    bool haveReplacedSection(const SectionName & sectionName) const;
 
     void writeReplacedSections(Elf_Off & curOff,
         Elf_Addr startAddr, Elf_Off startOffset);
@@ -209,7 +209,7 @@ public:
 
     void replaceNeeded(const std::map<std::string, std::string> & libs);
 
-    void printNeededLibs();
+    void printNeededLibs() /* should be const */;
 
     void noDefaultLib();
 
@@ -219,11 +219,11 @@ private:
        specified by the ELF header) to this platform's integer
        representation. */
     template<class I>
-    I rdi(I i);
+    I rdi(I i) const;
 
     /* Convert back to the ELF representation. */
     template<class I>
-    I wri(I & t, unsigned long long i)
+    I wri(I & t, unsigned long long i) const
     {
         t = rdi((I) i);
         return i;
@@ -235,7 +235,7 @@ private:
    why... */
 template<ElfFileParams>
 template<class I>
-I ElfFile<ElfFileParamNames>::rdi(I i)
+I ElfFile<ElfFileParamNames>::rdi(I i) const
 {
     I r = 0;
     if (littleEndian) {
@@ -569,7 +569,7 @@ void ElfFile<ElfFileParamNames>::shiftFile(unsigned int extraPages, Elf_Addr sta
 
 
 template<ElfFileParams>
-std::string ElfFile<ElfFileParamNames>::getSectionName(const Elf_Shdr & shdr)
+std::string ElfFile<ElfFileParamNames>::getSectionName(const Elf_Shdr & shdr) const
 {
     return std::string(sectionNames.c_str() + rdi(shdr.sh_name));
 }
@@ -578,7 +578,7 @@ std::string ElfFile<ElfFileParamNames>::getSectionName(const Elf_Shdr & shdr)
 template<ElfFileParams>
 Elf_Shdr & ElfFile<ElfFileParamNames>::findSection(const SectionName & sectionName)
 {
-    Elf_Shdr * shdr = findSection2(sectionName);
+    auto shdr = findSection2(sectionName);
     if (!shdr) {
         std::string extraMsg = "";
         if (sectionName == ".interp" || sectionName == ".dynamic" || sectionName == ".dynstr")
@@ -592,7 +592,7 @@ Elf_Shdr & ElfFile<ElfFileParamNames>::findSection(const SectionName & sectionNa
 template<ElfFileParams>
 Elf_Shdr * ElfFile<ElfFileParamNames>::findSection2(const SectionName & sectionName)
 {
-    unsigned int i = findSection3(sectionName);
+    auto i = findSection3(sectionName);
     return i ? &shdrs[i] : 0;
 }
 
@@ -606,13 +606,9 @@ unsigned int ElfFile<ElfFileParamNames>::findSection3(const SectionName & sectio
 }
 
 template<ElfFileParams>
-bool ElfFile<ElfFileParamNames>::haveReplacedSection(const SectionName & sectionName)
+bool ElfFile<ElfFileParamNames>::haveReplacedSection(const SectionName & sectionName) const
 {
-    ReplacedSections::iterator i = replacedSections.find(sectionName);
-
-    if (i != replacedSections.end())
-        return true;
-    return false;
+    return (replacedSections.find(sectionName) != replacedSections.end());
 }
 
 template<ElfFileParams>
@@ -625,7 +621,7 @@ std::string & ElfFile<ElfFileParamNames>::replaceSection(const SectionName & sec
     if (i != replacedSections.end()) {
         s = std::string(i->second);
     } else {
-        Elf_Shdr & shdr = findSection(sectionName);
+        auto shdr = findSection(sectionName);
         s = std::string((char *) contents + rdi(shdr.sh_offset), rdi(shdr.sh_size));
     }
 
@@ -652,7 +648,7 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
 
     for (auto & i : replacedSections) {
         std::string sectionName = i.first;
-        Elf_Shdr & shdr = findSection(sectionName);
+        auto & shdr = findSection(sectionName);
         debug("rewriting section '%s' from offset 0x%x (size %d) to offset 0x%x (size %d)\n",
             sectionName.c_str(), rdi(shdr.sh_offset), rdi(shdr.sh_size), curOff, i.second.size());
 
@@ -947,7 +943,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
     /* Update all those nasty virtual addresses in the .dynamic
        section.  Note that not all executables have .dynamic sections
        (e.g., those produced by klibc's klcc). */
-    Elf_Shdr * shdrDynamic = findSection2(".dynamic");
+    auto shdrDynamic = findSection2(".dynamic");
     if (shdrDynamic) {
         Elf_Dyn * dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic->sh_offset));
         unsigned int d_tag;
@@ -963,14 +959,14 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
             else if (d_tag == DT_GNU_HASH)
                 dyn->d_un.d_ptr = findSection(".gnu.hash").sh_addr;
             else if (d_tag == DT_JMPREL) {
-                Elf_Shdr * shdr = findSection2(".rel.plt");
+                auto shdr = findSection2(".rel.plt");
                 if (!shdr) shdr = findSection2(".rela.plt"); /* 64-bit Linux, x86-64 */
                 if (!shdr) shdr = findSection2(".rela.IA_64.pltoff"); /* 64-bit Linux, IA-64 */
                 if (!shdr) error("cannot find section corresponding to DT_JMPREL");
                 dyn->d_un.d_ptr = shdr->sh_addr;
             }
             else if (d_tag == DT_REL) { /* !!! hack! */
-                Elf_Shdr * shdr = findSection2(".rel.dyn");
+                auto shdr = findSection2(".rel.dyn");
                 /* no idea if this makes sense, but it was needed for some
                    program */
                 if (!shdr) shdr = findSection2(".rel.got");
@@ -980,7 +976,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
                 dyn->d_un.d_ptr = shdr->sh_addr;
             }
             else if (d_tag == DT_RELA) {
-                Elf_Shdr * shdr = findSection2(".rela.dyn");
+                auto shdr = findSection2(".rela.dyn");
                 /* some programs lack this section, but it doesn't seem to
                    be a problem */
                 if (!shdr) continue;
@@ -1009,7 +1005,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
                 }
                 std::string section = sectionsByOldIndex.at(shndx);
                 assert(!section.empty());
-                unsigned int newIndex = findSection3(section); // inefficient
+                auto newIndex = findSection3(section); // inefficient
                 //debug("rewriting symbol %d: index = %d (%s) -> %d\n", entry, shndx, section.c_str(), newIndex);
                 wri(sym->st_shndx, newIndex);
                 /* Rewrite st_value.  FIXME: we should do this for all
@@ -1033,7 +1029,7 @@ static void setSubstr(std::string & s, unsigned int pos, const std::string & t)
 template<ElfFileParams>
 std::string ElfFile<ElfFileParamNames>::getInterpreter()
 {
-    Elf_Shdr & shdr = findSection(".interp");
+    auto shdr = findSection(".interp");
     return std::string((char *) contents + rdi(shdr.sh_offset), rdi(shdr.sh_size));
 }
 
@@ -1045,8 +1041,8 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
         return;
     }
 
-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
+    auto shdrDynamic = findSection(".dynamic");
+    auto shdrDynStr = findSection(".dynstr");
     char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
 
     /* Walk through the dynamic section, look for the DT_SONAME entry. */
@@ -1130,11 +1126,11 @@ template<ElfFileParams>
 void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
     const std::vector<std::string> & allowedRpathPrefixes, std::string newRPath)
 {
-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
+    auto shdrDynamic = findSection(".dynamic");
 
     /* !!! We assume that the virtual address in the DT_STRTAB entry
        of the dynamic section corresponds to the .dynstr section. */
-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
+    auto shdrDynStr = findSection(".dynstr");
     char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
 
 
@@ -1322,8 +1318,8 @@ void ElfFile<ElfFileParamNames>::removeNeeded(const std::set<std::string> & libs
 {
     if (libs.empty()) return;
 
-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
+    auto shdrDynamic = findSection(".dynamic");
+    auto shdrDynStr = findSection(".dynstr");
     char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
 
     Elf_Dyn * dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
@@ -1350,8 +1346,8 @@ void ElfFile<ElfFileParamNames>::replaceNeeded(const std::map<std::string, std::
 {
     if (libs.empty()) return;
 
-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
+    auto shdrDynamic = findSection(".dynamic");
+    auto shdrDynStr = findSection(".dynstr");
     char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
 
     Elf_Dyn * dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
@@ -1396,7 +1392,7 @@ void ElfFile<ElfFileParamNames>::replaceNeeded(const std::map<std::string, std::
     // be replaced.
 
     if (verNeedNum) {
-        Elf_Shdr & shdrVersionR = findSection(".gnu.version_r");
+        auto shdrVersionR = findSection(".gnu.version_r");
         // The filename strings in the .gnu.version_r are different from the
         // ones in .dynamic: instead of being in .dynstr, they're in some
         // arbitrary section and we have to look in ->sh_link to figure out
@@ -1446,8 +1442,8 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
 {
     if (libs.empty()) return;
 
-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
+    auto shdrDynamic = findSection(".dynamic");
+    auto shdrDynStr = findSection(".dynstr");
 
     /* add all new libs to the dynstr string table */
     unsigned int length = 0;
@@ -1489,17 +1485,17 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
 }
 
 template<ElfFileParams>
-void ElfFile<ElfFileParamNames>::printNeededLibs()
+void ElfFile<ElfFileParamNames>::printNeededLibs() // const
 {
-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
-    char *strTab = (char *)contents + rdi(shdrDynStr.sh_offset);
+    const auto shdrDynamic = findSection(".dynamic");
+    const auto shdrDynStr = findSection(".dynstr");
+    const char *strTab = (char *)contents + rdi(shdrDynStr.sh_offset);
 
-    Elf_Dyn *dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
+    const Elf_Dyn *dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
 
     for (; rdi(dyn->d_tag) != DT_NULL; dyn++) {
         if (rdi(dyn->d_tag) == DT_NEEDED) {
-            char *name = strTab + rdi(dyn->d_un.d_val);
+            const char *name = strTab + rdi(dyn->d_un.d_val);
             printf("%s\n", name);
         }
     }
@@ -1509,7 +1505,7 @@ void ElfFile<ElfFileParamNames>::printNeededLibs()
 template<ElfFileParams>
 void ElfFile<ElfFileParamNames>::noDefaultLib()
 {
-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
+    auto shdrDynamic = findSection(".dynamic");
 
     Elf_Dyn * dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
     Elf_Dyn * dynFlags1 = 0;


### PR DESCRIPTION
As I was reviewing the solution to #67, I noted that some methods should be `const`.