### PR TITLE
Improve the default section alignment choice (> 4K page size compat)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,23 +7,16 @@ AM_INIT_AUTOMAKE([1.11.1 -Wall -Werror dist-bzip2 foreign color-tests parallel-t
 AM_PROG_CC_C_O
 AC_PROG_CXX
 
-PAGESIZE=auto
+DEFAULT_PAGESIZE=auto
 AC_ARG_WITH([page-size],
    AS_HELP_STRING([--with-page-size=SIZE], [Specify default pagesize (default auto)]),
-   PAGESIZE=$withval
+   DEFAULT_PAGESIZE=$withval
 )
 
-if test "$PAGESIZE" = auto; then
-    if command -v getconf >/dev/null; then
-        PAGESIZE=$(getconf PAGESIZE || getconf PAGE_SIZE)
-    fi
-    if test "$PAGESIZE" = auto -o -z "$PAGESIZE"; then
-        PAGESIZE=4096
-    fi
+if test "$DEFAULT_PAGESIZE" != auto; then
+    AC_DEFINE_UNQUOTED(DEFAULT_PAGESIZE, ${DEFAULT_PAGESIZE})
+    AC_MSG_RESULT([Setting page size to ${DEFAULT_PAGESIZE}])
 fi
-
-AC_DEFINE_UNQUOTED(PAGESIZE, ${PAGESIZE})
-AC_MSG_RESULT([Setting page size to ${PAGESIZE}])
 
 AC_ARG_WITH([asan],
    AS_HELP_STRING([--with-asan], [Link with libasan])


### PR DESCRIPTION
(This is a second attempt at what #80 implemented. It fixes issue #79.)

Currently patchelf uses the host system's page size (determined at build
time) as the default section load memory alignment. This causes multiple
issues

- Cross-compilation: when using patchelf on ELFs targetting a different
  architecture from the host, the host page size is still used by
  default.

- Variable page size architectures: ARMv8 systems can be configured in
  either 4K, 16K, or 64K page size mode depending on kernel
  configuration. An ARMv8 patchelf built on a 4K page size system will
  end up creating ELFs that cannot be used on a 64K page size system.

- Reproducibility: the page size of the machine that built patchelf
  "leaks" into the binary.

The build time --with-page-size as well as the run time --page-size
options can be used to work around some of these issues. But it's much
better to have patchelf do the right thing without explicit
configuration.

This commit adds support for inferring page size from the ELF header's
"machine" field. The default values are extracted from GNU gold's source
code. Note that both --with-page-size as well as --page-size continue to
work and take precedence on the default value.