### PR TITLE
use stable_sort to maintain relative order for equal elements in sections

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -474,7 +474,7 @@ void ElfFile<ElfFileParamNames>::sortPhdrs()
     /* Sort the segments by offset. */
     CompPhdr comp;
     comp.elfFile = this;
-    sort(phdrs.begin(), phdrs.end(), comp);
+    stable_sort(phdrs.begin(), phdrs.end(), comp);
 }
 
 
@@ -501,7 +501,7 @@ void ElfFile<ElfFileParamNames>::sortShdrs()
     /* Sort the sections by offset. */
     CompShdr comp;
     comp.elfFile = this;
-    sort(shdrs.begin() + 1, shdrs.end(), comp);
+    stable_sort(shdrs.begin() + 1, shdrs.end(), comp);
 
     /* Restore the sh_link mappings. */
     for (unsigned int i = 1; i < rdi(hdr->e_shnum); ++i)


### PR DESCRIPTION
replaces the usage of sort with stable_sort as ordering for equal elements is undefined for std::sort.