### PR TITLE
patchelf: Check ELF endianness before writing new runpath

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1381,11 +1381,11 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
 
 
     if (!forceRPath && dynRPath && !dynRunPath) { /* convert DT_RPATH to DT_RUNPATH */
-        dynRPath->d_tag = DT_RUNPATH;
+        wri(dynRPath->d_tag, DT_RUNPATH);
         dynRunPath = dynRPath;
         dynRPath = 0;
     } else if (forceRPath && dynRunPath) { /* convert DT_RUNPATH to DT_RPATH */
-        dynRunPath->d_tag = DT_RPATH;
+        wri(dynRunPath->d_tag, DT_RPATH);
         dynRPath = dynRunPath;
         dynRunPath = 0;
     } else if (std::string(rpath ? rpath : "") == newRPath) {


### PR DESCRIPTION
This commit modifies the way fields are written in the dynamic
section in order to account the architecture of the target ELF
file. Instead of copying the raw data, use the helper functions
to convert endianness.

Signed-off-by: Bryce Ferguson <bryce.ferguson@rockwellcollins.com>


Just fixed the merge conflicts from #151, no significant addition from me. Closes #151.