### PR TITLE
[BUG FIX] false alarm for non overlapping sections

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -669,6 +669,7 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
             memset(contents + rdi(shdr.sh_offset), 'X', rdi(shdr.sh_size));
     }
 
+    std::set<unsigned int> noted_phdrs = {};
     for (auto & i : replacedSections) {
         std::string sectionName = i.first;
         auto & shdr = findSection(sectionName);
@@ -721,7 +722,7 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
                 shdr.sh_addralign = orig_shdr.sh_addralign;
 
             for (unsigned int j = 0; j < phdrs.size(); ++j)
-                if (rdi(phdrs[j].p_type) == PT_NOTE) {
+                if (rdi(phdrs[j].p_type) == PT_NOTE && noted_phdrs.find(j) == noted_phdrs.end()) {
                     Elf_Off p_start = rdi(phdrs[j].p_offset);
                     Elf_Off p_end = p_start + rdi(phdrs[j].p_filesz);
                     Elf_Off s_start = rdi(orig_shdr.sh_offset);
@@ -739,6 +740,8 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
                     phdrs[j].p_offset = shdr.sh_offset;
                     phdrs[j].p_vaddr = phdrs[j].p_paddr = shdr.sh_addr;
                     phdrs[j].p_filesz = phdrs[j].p_memsz = shdr.sh_size;
+
+                    noted_phdrs.insert(j);
                 }
         }
 


### PR DESCRIPTION
#### What these changes do
avoids recheck of marked note segments already synced with note sections,

This also serves as a bug fix when a previously synced note segment
overlaps with another section.


## Steps to reproduce the bug


```
pushd /tmp

wget -O util-linux.bottle.tar.gz "https://bintray.com/linuxbrew/bottles/download_file?file_path=util-linux-2.36.x86_64_linux.bottle.tar.gz"
tar -zxf util-linux.bottle.tar.gz
chmod +w util-linux/2.36/bin/chmem
patchelf --force-rpath --set-rpath "ngcfpqardtudtlvqujdskyvgehsyxyxawbqchomweuxfbvfrfekhgnrtlsftwwjcpvoyedaoaikgkgyxmodpkafkcubibuiasuabbziihwijnfjnsqpqmlcwzxzxvphnclpqezyjrtetcmomldsh" /tmp/util-linux/2.36/bin/chmem

```

## Description of bug

Running the above described commands fails with
 > patchelf: unsupported overlap of SHT_NOTE and PT_NOTE

### why is this happening ?

https://github.com/NixOS/patchelf/blob/7aa6b90851eba4eeb59bc75cbf40866fbce7b386/src/patchelf.cc#L725-L741

In the above link, the previously updated program header will be compared against un updated section header(`orig_shdr`)


### verbose explanation

i'll paste the `PATCHELF_DEBUG=1` log here,
if the log makes sense,  please skip the writing.

```
patching ELF file '/tmp/util-linux/2.36/bin/chmem'
new rpath is 'ngcfpqardtudtlvqujdskyvgehsyxyxawbqchomweuxfbvfrfekhgnrtlsftwwjcpvoyedaoaikgkgyxmodpkafkcubibuiasuabbziihwijnfjnsqpqmlcwzxzxvphnclpqezyjrtetcmomldsh'
rpath is too long, resizing...
replacing section '.dynstr' with size 1365
this is an executable
using replaced section '.dynstr'
last replaced is 6
looking at section '.interp'
replacing section '.interp' which is in the way
looking at section '.note.ABI-tag'
replacing section '.note.ABI-tag' which is in the way
looking at section '.note.gnu.build-id'
replacing section '.note.gnu.build-id' which is in the way
looking at section '.gnu.hash'
replacing section '.gnu.hash' which is in the way
looking at section '.dynsym'
replacing section '.dynsym' which is in the way
looking at section '.dynstr'
first reserved offset/addr is 0x11b0/0x4011b0
first page is 0x400000
needed space is 4728
needed space is 4784
needed pages is 1
changing alignment of program header 2 from 2097152 to 4096
changing alignment of program header 6 from 2097152 to 4096
clearing first 7944 bytes
rewriting section '.dynstr' from offset 0x1cf0 (size 1216) to offset 0x2a8 (size 1365)
rewriting section '.dynsym' from offset 0x12e8 (size 2568) to offset 0x800 (size 2568)
rewriting section '.gnu.hash' from offset 0x12a8 (size 64) to offset 0x1208 (size 64)
rewriting section '.interp' from offset 0x1238 (size 30) to offset 0x1248 (size 30)
rewriting section '.note.ABI-tag' from offset 0x1260 (size 32) to offset 0x1268 (size 32)
rewriting section '.note.gnu.build-id' from offset 0x1280 (size 36) to offset 0x1288 (size 36)
patchelf: unsupported overlap of SHT_NOTE and PT_NOTE
```

orig_shdr = `.note.ABI-tag` is at `0x1260`
it finds a matching segment from `0x1260` to `0x1280`
and updates the phdr values to new shdr values 
which is  `0x1268` .. `0x1288`

for the next replaced_section 
orig_shdr = `.note.gnu.build-id` is at `0x1280`
it checks for overlap between `0x1280` .. `0x12a4`
the previously updated phdr( `0x1268` .. `0x1288`) 
overlaps with this section. 


phew :disappointed_relieved: 

Another point being, 
it doesn't make sense to check the program once mapped to section
as the whole point of normalize note sections is to create 1 - 1 mapping 
between section and segments.


Alternative ways to resolve the issue are welcome.
Thanks

