### PR TITLE
skip overwriting r(un)path data when old_rpath = new_rpath.

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1384,11 +1384,15 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
         wri(dynRPath->d_tag, DT_RUNPATH);
         dynRunPath = dynRPath;
         dynRPath = 0;
+        changed = true;
     } else if (forceRPath && dynRunPath) { /* convert DT_RUNPATH to DT_RPATH */
         wri(dynRunPath->d_tag, DT_RPATH);
         dynRPath = dynRunPath;
         dynRunPath = 0;
-    } else if (std::string(rpath ? rpath : "") == newRPath) {
+        changed = true;
+    }
+
+    if (std::string(rpath ? rpath : "") == newRPath) {
         return;
     }
 


### PR DESCRIPTION
https://github.com/NixOS/patchelf/blob/7aa6b90851eba4eeb59bc75cbf40866fbce7b386/src/patchelf.cc#L1383-L1393

When the `force-rpath` is true and `DT_RUNPATH` exists, 
the conditional for old_rpath = new_rpath is not checked.
causing it to rewrite rpath data even when new_rpath = old_rpath.

similar problem when `!forceRPath && dynRPath && !dynRunPath` is true.
