### PR TITLE
fix roundUp() to not truncate 64 bit values

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -541,7 +541,7 @@ static void writeFile(std::string fileName, FileContents contents)
 }
 
 
-static unsigned int roundUp(unsigned int n, unsigned int m)
+static uint64_t roundUp(uint64_t n, uint64_t m)
 {
     return ((n - 1) / m + 1) * m;
 }


### PR DESCRIPTION
Fixes: #224 