### PR TITLE
Use sh_offset instead of sh_addr when checking already replaced libs

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -778,7 +778,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
     /* Some sections may already be replaced so account for that */
     unsigned int i = 1;
     Elf_Addr pht_size = sizeof(Elf_Ehdr) + (phdrs.size() + num_notes + 1)*sizeof(Elf_Phdr);
-    while( shdrs[i].sh_addr <= pht_size && i < rdi(hdr->e_shnum) ) {
+    while( shdrs[i].sh_offset <= pht_size && i < rdi(hdr->e_shnum) ) {
         if (not haveReplacedSection(getSectionName(shdrs[i])))
             replaceSection(getSectionName(shdrs[i]), shdrs[i].sh_size);
         i++;


### PR DESCRIPTION
When checking for already replaced libs, the check against the size must
be done using the section header offset, not the section file address.
This was not crashing in many situations because normally sh_address and
sh_offset have the same value but these two may differ and using the
sh_address value instead can cause library corruption in these
situations.

Closes: #239