### PR TITLE
Added option --add-rpath

### DIFF
--- a/patchelf.1
+++ b/patchelf.1
@@ -43,6 +43,9 @@ Sets DT_SONAME entry of a library to SONAME.
 .IP "--set-rpath RPATH"
 Change the RPATH of the executable or library to RPATH.
 
+.IP "--add-rpath RPATH"
+Add RPATH to the existing RPATH of the executable or library.
+
 .IP --remove-rpath
 Removes the DT_RPATH or DT_RUNPATH entry of the executable or library.
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1939,6 +1939,9 @@ int mainWrapped(int argc, char * * argv)
     if (!outputFileName.empty() && fileNames.size() != 1)
         error("--output option only allowed with single input file");
 
+    if (setRPath && addRPath)
+        error("--set-rpath option not allowed with --add-rpath");
+
     patchElf();
 
     return 0;

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -201,7 +201,7 @@ public:
 
     void setInterpreter(const std::string & newInterpreter);
 
-    typedef enum { rpPrint, rpShrink, rpSet, rpRemove } RPathOp;
+    typedef enum { rpPrint, rpShrink, rpSet, rpAdd, rpRemove } RPathOp;
 
     void modifyRPath(RPathOp op, const std::vector<std::string> & allowedRpathPrefixes, std::string newRPath);
 
@@ -1396,6 +1396,10 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
         return;
     }
 
+    if (op == rpAdd) {
+        newRPath = std::string(rpath ? rpath : "") + ":" + newRPath; 
+    }
+
     changed = true;
 
     /* Zero out the previous rpath to prevent retained dependencies in
@@ -1715,6 +1719,7 @@ static bool shrinkRPath = false;
 static std::vector<std::string> allowedRpathPrefixes;
 static bool removeRPath = false;
 static bool setRPath = false;
+static bool addRPath = false;
 static bool printRPath = false;
 static std::string newRPath;
 static std::set<std::string> neededLibsToRemove;
@@ -1748,6 +1753,8 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, std
         elfFile.modifyRPath(elfFile.rpRemove, {}, "");
     else if (setRPath)
         elfFile.modifyRPath(elfFile.rpSet, {}, newRPath);
+    else if (addRPath)
+        elfFile.modifyRPath(elfFile.rpAdd, {}, newRPath);
 
     if (printNeeded) elfFile.printNeededLibs();
 
@@ -1795,6 +1802,7 @@ void showHelp(const std::string & progName)
   [--print-soname]\t\tPrints 'DT_SONAME' entry of .dynamic section. Raises an error if DT_SONAME doesn't exist\n\
   [--set-soname SONAME]\t\tSets 'DT_SONAME' entry to SONAME.\n\
   [--set-rpath RPATH]\n\
+  [--add-rpath RPATH]\n\
   [--remove-rpath]\n\
   [--shrink-rpath]\n\
   [--allowed-rpath-prefixes PREFIXES]\t\tWith '--shrink-rpath', reject rpath entries not starting with the allowed prefix\n\
@@ -1858,6 +1866,11 @@ int mainWrapped(int argc, char * * argv)
         else if (arg == "--set-rpath") {
             if (++i == argc) error("missing argument");
             setRPath = true;
+            newRPath = argv[i];
+        }
+        else if (arg == "--add-rpath") {
+            if (++i == argc) error("missing argument");
+            addRPath = true;
             newRPath = argv[i];
         }
         else if (arg == "--print-rpath") {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,7 +20,7 @@ no_rpath_arch_TESTS = \
 
 src_TESTS = \
   plain-fail.sh plain-run.sh shrink-rpath.sh set-interpreter-short.sh \
-  set-interpreter-long.sh set-rpath.sh no-rpath.sh big-dynstr.sh \
+  set-interpreter-long.sh set-rpath.sh add-rpath.sh no-rpath.sh big-dynstr.sh \
   set-rpath-library.sh soname.sh shrink-rpath-with-allowed-prefixes.sh \
   force-rpath.sh \
   plain-needed.sh \

--- a/tests/add-rpath.sh
+++ b/tests/add-rpath.sh
@@ -1,0 +1,28 @@
+#! /bin/sh -e
+SCRATCH=scratch/$(basename $0 .sh)
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+mkdir -p ${SCRATCH}/libsA
+mkdir -p ${SCRATCH}/libsB
+
+cp main ${SCRATCH}/
+cp libfoo.so ${SCRATCH}/libsA/
+cp libbar.so ${SCRATCH}/libsB/
+
+../src/patchelf --force-rpath --add-rpath $(pwd)/${SCRATCH}/libsA ${SCRATCH}/main
+../src/patchelf --force-rpath --add-rpath $(pwd)/${SCRATCH}/libsB ${SCRATCH}/main
+#patchelf --add-rpath $(pwd)/${SCRATCH}/libsA ${SCRATCH}/main
+#patchelf --add-rpath $(pwd)/${SCRATCH}/libsB ${SCRATCH}/main
+
+if test "$(uname)" = FreeBSD; then
+    export LD_LIBRARY_PATH=$(pwd)/${SCRATCH}/libsB
+fi
+
+exitCode=0
+(cd ${SCRATCH} && ./main) || exitCode=$?
+
+if test "$exitCode" != 46; then
+    echo "bad exit code!"
+    exit 1
+fi

--- a/tests/add-rpath.sh
+++ b/tests/add-rpath.sh
@@ -12,8 +12,6 @@ cp libbar.so ${SCRATCH}/libsB/
 
 ../src/patchelf --force-rpath --add-rpath $(pwd)/${SCRATCH}/libsA ${SCRATCH}/main
 ../src/patchelf --force-rpath --add-rpath $(pwd)/${SCRATCH}/libsB ${SCRATCH}/main
-#patchelf --add-rpath $(pwd)/${SCRATCH}/libsA ${SCRATCH}/main
-#patchelf --add-rpath $(pwd)/${SCRATCH}/libsB ${SCRATCH}/main
 
 if test "$(uname)" = FreeBSD; then
     export LD_LIBRARY_PATH=$(pwd)/${SCRATCH}/libsB


### PR DESCRIPTION
New option --add-rpath makes it possible to just add a new entry to the rpath list preserving the existing ones in one operation. This avoids having to run  patchelf --print-rpath, save the current value in a variable, append the new path to the variable and then patchelf --set-rpath.