### PR TITLE
Fix Github action by updating install-nix-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v9
+    - uses: cachix/install-nix-action@v12
       with: 
         skip_adding_nixpkgs_channel: true
     - run: nix-build release.nix


### PR DESCRIPTION
install-nix-action v9 still uses the now deprecated add-path command.
This results in ugly errors:

```
Error: Unable to process command '::add-path::/nix/var/nix/profiles/per-user/runner/profile/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Update to v12 to fix this.

@edolstra @domenkozar 