### PR TITLE
Remove limits on output file size.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Makefile
 /tests/main-scoped
 /tests/libbig-dynstr.debug
 /tests/contiguous-note-sections
+/tests/simple-pie

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ src_TESTS = \
   endianness.sh \
   contiguous-note-sections.sh \
   no-gnu-hash.sh \
+  grow-file.sh \
   no-dynamic-section.sh \
   args-from-file.sh \
   basic-flags.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,7 @@ LIBS =
 
 STRIP ?= strip
 
-check_PROGRAMS = simple main too-many-strtab main-scoped big-dynstr no-rpath contiguous-note-sections
+check_PROGRAMS = simple-pie simple main too-many-strtab main-scoped big-dynstr no-rpath contiguous-note-sections
 
 no_rpath_arch_TESTS = \
   no-rpath-amd64.sh \
@@ -67,6 +67,9 @@ export NIX_LDFLAGS=
 simple_SOURCES = simple.c
 # no -fpic for simple.o
 simple_CFLAGS =
+
+simple_pie_SOURCES = simple.c
+simple_pie_CFLAGS = -fPIC -pie
 
 main_SOURCES = main.c
 main_LDADD = -lfoo $(AM_LDADD)

--- a/tests/grow-file.sh
+++ b/tests/grow-file.sh
@@ -5,12 +5,12 @@ SCRATCH=scratch/$(basename $0 .sh)
 rm -rf ${SCRATCH}
 mkdir -p ${SCRATCH}
 
-g++ -x c -fPIC -pie -o ${SCRATCH}/simple simple.c
+cp simple-pie ${SCRATCH}/simple-pie
 
 # Add a 40MB rpath
 head -c 40000000 /dev/urandom > ${SCRATCH}/foo.bin
 
 # Grow the file
-../src/patchelf --add-rpath @${SCRATCH}/foo.bin ${SCRATCH}/simple
+../src/patchelf --add-rpath @${SCRATCH}/foo.bin ${SCRATCH}/simple-pie
 # Make sure we can still run it
-${SCRATCH}/simple
+${SCRATCH}/simple-pie

--- a/tests/grow-file.sh
+++ b/tests/grow-file.sh
@@ -1,0 +1,16 @@
+#! /bin/sh -e
+
+SCRATCH=scratch/$(basename $0 .sh)
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+
+g++ -x c -fPIC -pie -o ${SCRATCH}/simple simple.c
+
+# Add a 40MB rpath
+head -c 40000000 /dev/urandom > ${SCRATCH}/foo.bin
+
+# Grow the file
+../src/patchelf --add-rpath @${SCRATCH}/foo.bin ${SCRATCH}/simple
+# Make sure we can still run it
+${SCRATCH}/simple


### PR DESCRIPTION
> The use of self-pointers into a vector<> meant that the vector could not be relocated, which meant that any growth in the file had to fit within the initial reservation.

> Now, instead of a pointer to a header and a pointer to the contents, those values are computed dynamically from the underlying vector().

I made an attempt at writing a test that would provide coverage, but couldn't make it work. If you have suggestions for writing a test to test this functionality, please let me know and I'll give it a shot.