### PR TITLE
fix wrong cast

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -397,13 +397,13 @@ ElfFile<ElfFileParamNames>::ElfFile(FileContents fileContents)
     if (rdi(hdr->e_type) != ET_EXEC && rdi(hdr->e_type) != ET_DYN)
         error("wrong ELF type");
 
-    if (size_t(rdi(hdr->e_phoff) + rdi(hdr->e_phnum)) * rdi(hdr->e_phentsize) > fileContents->size())
+    if (rdi(hdr->e_phoff) + size_t(rdi(hdr->e_phnum) * rdi(hdr->e_phentsize)) > fileContents->size())
         error("program header table out of bounds");
 
     if (rdi(hdr->e_shnum) == 0)
         error("no section headers. The input file is probably a statically linked, self-decompressing binary");
 
-    if (size_t(rdi(hdr->e_shoff) + rdi(hdr->e_shnum)) * rdi(hdr->e_shentsize) > fileContents->size())
+    if (rdi(hdr->e_shoff) + size_t(rdi(hdr->e_shnum) * rdi(hdr->e_shentsize)) > fileContents->size())
         error("section header table out of bounds");
 
     if (rdi(hdr->e_phentsize) != sizeof(Elf_Phdr))


### PR DESCRIPTION
The original code which worked was size_t(A + B * C). size_t(A + B)
breaks it. A + size_t(B * C) is correct.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be perserved.
