### PR TITLE
convert endian when checking library machine type

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1346,7 +1346,8 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
                 if (!neededLibFound[j]) {
                     std::string libName = dirName + "/" + neededLibs[j];
                     try {
-                        if (getElfType(readFile(libName, sizeof(Elf32_Ehdr))).machine == rdi(hdr->e_machine)) {
+                        Elf32_Half library_e_machine = getElfType(readFile(libName, sizeof(Elf32_Ehdr))).machine;
+                        if (rdi(library_e_machine) == rdi(hdr->e_machine)) {
                             neededLibFound[j] = true;
                             libFound = true;
                         } else


### PR DESCRIPTION
I haven't figured out a regression test yet, just wanted to get this out there. I will have a look at that tomorrow

Problem: when running `patchelf --shrink-rpath some-binary` on a big-endian MIPS binary it removes all 
the rpath entries  and leaves the rpath empty

```
[nix-shell:/tmp/ll/monit-5.27.2]$ file  /tmp/monit 
/tmp/monit: ELF 32-bit MSB pie executable, MIPS, MIPS32 version 1 (SYSV), dynamically linked, interpreter /nix/store/vyb009fykg09m83qdnxl5psbk1qiaj8f-musl-1.2.2-mips-unknown-linux-musl/lib/ld-musl-mips.so.1, with debug_info, not stripped
[nix-shell:/tmp/ll/monit-5.27.2]$ /tmp/patchelf --debug --shrink-rpath /tmp/monit 
patching ELF file '/tmp/monit'
removing directory '/nix/store/3f0lslza6whnv0nxcimk3nw10n4n14sx-monit-5.27.2-mips-unknown-linux-musl/lib64' from RPATH
removing directory '/nix/store/3f0lslza6whnv0nxcimk3nw10n4n14sx-monit-5.27.2-mips-unknown-linux-musl/lib' from RPATH
ignoring library '/nix/store/p686d12xrksl8ljahmqdv78q72jg5p3v-zlib-1.2.11-mips-unknown-linux-musl/lib/libz.so.1' because its machine type differs
removing directory '/nix/store/p686d12xrksl8ljahmqdv78q72jg5p3v-zlib-1.2.11-mips-unknown-linux-musl/lib' from RPATH
ignoring library '/nix/store/vyb009fykg09m83qdnxl5psbk1qiaj8f-musl-1.2.2-mips-unknown-linux-musl/lib/libc.so' because its machine type differs
removing directory '/nix/store/vyb009fykg09m83qdnxl5psbk1qiaj8f-musl-1.2.2-mips-unknown-linux-musl/lib' from RPATH
removing directory '/nix/store/f6fxm3fw6gmwdv45x9vf3ijddvbwcbjw-mips-unknown-linux-musl-stage-final-gcc-debug-10.2.0-lib/mips-unknown-linux-musl/lib' from RPATH
new rpath is ''
writing /tmp/monit

```

----

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be perserved.
