### PR TITLE
patchelf: Fix alignment issues with contiguous note sections

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1025,6 +1025,8 @@ void ElfFile<ElfFileParamNames>::normalizeNoteSegments()
                 phdrs.push_back(new_phdr);
 
             curr_off += size;
+            /* The next section offset would be aligned */
+            curr_off = roundUp(curr_off, sectionAlignment);
         }
     }
     wri(hdr->e_phnum, phdrs.size());


### PR DESCRIPTION
If a binary has multiple SHT_NOTE sections and corresponding PT_NOTE
headers, we can see the error:

patchelf: cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections

if the SHT_NOTE sections aren't sized to end on aligned boundaries. An example
would be a binary with:

  [ 2] .note.ABI-tag     NOTE             00000000000002f4  000002f4
       0000000000000020  0000000000000000   A       0     0     4
  [ 3] .note.gnu.propert NOTE             0000000000000318  00000318
       0000000000000030  0000000000000000   A       0     0     8
  [ 4] .note.gnu.build-i NOTE             0000000000000348  00000348
       0000000000000024  0000000000000000   A       0     0     4

  NOTE           0x0000000000000318 0x0000000000000318 0x0000000000000318
                 0x0000000000000030 0x0000000000000030  R      0x8
  NOTE           0x00000000000002f4 0x00000000000002f4 0x00000000000002f4
                 0x0000000000000078 0x0000000000000074  R      0x4

since the PT_NOTE section at 2f4 covers [2] and [3] but the code
calclates curr_off should be 314, not the 318 in the binary. This
is an alignment issue.

To fix this, we need to round curr_off to the next section alignment.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be perserved.
