### PR TITLE
Add testfile for PR270

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1057,7 +1057,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
 
     /* If there is a segment for the program header table, update it.
        (According to the ELF spec, there can only be one.) */
-    for (auto phdr : phdrs) {
+    for (auto &phdr : phdrs) {
         if (rdi(phdr.p_type) == PT_PHDR) {
             phdr.p_offset = hdr->e_phoff;
             wri(phdr.p_vaddr, wri(phdr.p_paddr, phdrAddress));

--- a/tests/replace-needed.sh
+++ b/tests/replace-needed.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -ex
+cat << EOF > hello.c
+#include <stdio.h>
+int main() {
+   printf("Hello, World!");
+   return 0;
+}
+EOF
+gcc hello.c -o hello -no-pie
+interpreter=$(../src/patchelf --print-interpreter ./hello)
+cp ./hello ./hello.orig
+../src/patchelf --set-interpreter $interpreter ./hello
+../src/patchelf --replace-needed libc.so.6  $interpreter ./hello
+./hello.orig
+./hello


### PR DESCRIPTION
Since https://github.com/NixOS/patchelf/pull/270 has been waiting for a month, and @0xling already did the work...

Previously:
```
./replace-needed.sh 
+ cat
+ gcc hello.c -o hello -no-pie
+ ../src/patchelf --print-interpreter ./hello
+ interpreter=/lib64/ld-linux-x86-64.so.2
+ cp ./hello ./hello.orig
+ ../src/patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 ./hello
+ ../src/patchelf --replace-needed libc.so.6 /lib64/ld-linux-x86-64.so.2 ./hello
+ ./hello.orig
Hello, World!+ ./hello
Segmentation fault (core dumped)
```

With the patch:
```
./replace-needed.sh 
+ cat
+ gcc hello.c -o hello -no-pie
+ ../src/patchelf --print-interpreter ./hello
+ interpreter=/lib64/ld-linux-x86-64.so.2
+ cp ./hello ./hello.orig
+ ../src/patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 ./hello
+ ../src/patchelf --replace-needed libc.so.6 /lib64/ld-linux-x86-64.so.2 ./hello
+ ./hello.orig
Hello, World!+ ./hello
./hello: relocation error: ./hello: symbol __libc_start_main version GLIBC_2.2.5 not defined in file /lib64/ld-linux-x86-64.so.2 with link time reference
```