### PR TITLE
Fix updating program header table segment

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1057,7 +1057,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
 
     /* If there is a segment for the program header table, update it.
        (According to the ELF spec, there can only be one.) */
-    for (auto phdr : phdrs) {
+    for (auto & phdr : phdrs) {
         if (rdi(phdr.p_type) == PT_PHDR) {
             phdr.p_offset = hdr->e_phoff;
             wri(phdr.p_vaddr, wri(phdr.p_paddr, phdrAddress));


### PR DESCRIPTION
Without '&', the code updates temporary and thus does essentially nothing. But updating PT_PHDR segment is required for many architectures.

Fixes: dd4d2af8dbd348d18b5b4ab6dbef43a22d9cb0b1

For current master (f376fe61bae57e9e50f4622f5a44febb4f5bfd3c) tests are failing on aarch64 (Raspberry Pi 4 running 64-bit  Linux):

```
make[3]: Entering directory '/home/user/patchelf/tests'
PASS: plain-run.sh
PASS: plain-fail.sh
PASS: set-interpreter-short.sh
PASS: shrink-rpath.sh
FAIL: set-interpreter-long.sh
FAIL: set-rpath.sh
FAIL: no-rpath.sh
FAIL: big-dynstr.sh
PASS: soname.sh
FAIL: set-rpath-library.sh
PASS: plain-needed.sh
PASS: shrink-rpath-with-allowed-prefixes.sh
FAIL: output-flag.sh
PASS: no-rpath-pie-powerpc.sh
PASS: force-rpath.sh
PASS: build-id.sh
PASS: invalid-elf.sh
PASS: no-rpath-armel.sh
PASS: no-rpath-amd64.sh
PASS: no-rpath-armhf.sh
PASS: no-rpath-hurd-i386.sh
PASS: no-rpath-i386.sh
PASS: no-rpath-kfreebsd-amd64.sh
PASS: no-rpath-ia64.sh
PASS: no-rpath-kfreebsd-i386.sh
PASS: no-rpath-mips.sh
PASS: no-rpath-powerpc.sh
PASS: no-rpath-mipsel.sh
PASS: no-rpath-s390.sh
PASS: no-rpath-sh4.sh
PASS: no-rpath-sparc.sh
============================================================================
Testsuite summary for patchelf 0.12
============================================================================
# TOTAL: 31
# PASS:  25
# SKIP:  0
# XFAIL: 0
# FAIL:  6
# XPASS: 0
# ERROR: 0
```

This commit fixes that.

Actually, I discovered this issue on `mipsel` machine when I was rebasing my MIPS-related patches onto the current master. I could not reproduce the issue on x86_64, so I'm not sure how to add a new testcase.