### PR TITLE
rewriteSectionsLibrary: Fix endianness issue

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -851,7 +851,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
     assert(curOff == startOffset + neededSpace);
 
     /* Write out the updated program and section headers */
-    rewriteHeaders(firstPage + hdr->e_phoff);
+    rewriteHeaders(firstPage + rdi(hdr->e_phoff));
 }
 
 


### PR DESCRIPTION
The tests are failing on my machine for current master (251b98cac), because patchelf creats a broken PPC binary in tests/no-rpath-pie-powerpc.sh:

```
$ readelf -l scratch/no-rpath-pie-powerpc/no-rpath
[...]
Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  PHDR           0x000034 0x34000000 0x34000000 0x00120 0x00120 R   0x4
[...]
```

That happens because 4efbce41 lost endianness conversion for rewriteSectionsLibrary. This commit puts it back.

Fixes: 4efbce410d00c8cb43f134181d07b364bcf78022