### PR TITLE
tests: add testcase for alignment issues with contiguous note sections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AM_INIT_AUTOMAKE([1.11.1 -Wall -Werror dist-bzip2 foreign color-tests parallel-t
 
 AM_PROG_CC_C_O
 AC_PROG_CXX
+AM_PROG_AS
 
 DEFAULT_PAGESIZE=auto
 AC_ARG_WITH([page-size],

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 LIBS =
 
-check_PROGRAMS = simple main main-scoped big-dynstr no-rpath
+check_PROGRAMS = simple main main-scoped big-dynstr no-rpath contiguous_note_sections
 
 no_rpath_arch_TESTS = \
   no-rpath-amd64.sh \
@@ -27,7 +27,8 @@ src_TESTS = \
   output-flag.sh \
   no-rpath-pie-powerpc.sh \
   build-id.sh \
-  invalid-elf.sh
+  invalid-elf.sh \
+  contiguous_note_sections.sh
 
 build_TESTS = \
   $(no_rpath_arch_TESTS)
@@ -106,3 +107,6 @@ libsimple_so_LDFLAGS = $(LDFLAGS_sharedlib)
 no_rpath_SOURCES = no-rpath.c
 # no -fpic for no-rpath.o
 no_rpath_CFLAGS =
+
+contiguous_note_sections_SOURCES = contiguous_note_sections.s
+contiguous_note_sections_CFLAGS = -nostdlib -T contiguous_note_sections.ld

--- a/tests/contiguous_note_sections.ld
+++ b/tests/contiguous_note_sections.ld
@@ -1,0 +1,22 @@
+PHDRS
+{
+  headers PT_PHDR PHDRS ;
+  notes PT_NOTE;
+  text PT_LOAD FILEHDR PHDRS ;
+  data PT_LOAD ;
+  interp PT_INTERP ;
+  dynamic PT_DYNAMIC ;
+}
+
+SECTIONS
+{
+  . = SIZEOF_HEADERS;
+  .note.my-section0 : { *(.note.my-section0) } :notes :text
+  .note.my-section1 : { *(.note.my-section1) } :notes :text
+
+  .interp : { *(.interp) } :text :interp
+  .text : { *(.text) } :text
+  .rodata : { *(.rodata) } /* defaults to :text */
+
+  .data : { *(.data) } :data
+}

--- a/tests/contiguous_note_sections.s
+++ b/tests/contiguous_note_sections.s
@@ -1,0 +1,23 @@
+/*
+ * Testcase for error:
+ * patchelf: cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections
+ */
+.section ".note.my-section0", "a", @note
+    .align 4
+    .long 1f - 0f              /* name length (not including padding) */
+    .long 3f - 2f              /* desc length (not including padding) */
+    .long 1                    /* type = NT_VERSION */
+0:  .asciz "my-version-12345" /* name */
+1:  .align 4
+2:  .long 1                    /* desc - toolchain version number, 32-bit LE */
+3:  .align 4
+
+.section ".note.my-section1", "a", @note
+    .align 8
+    .long 1f - 0f              /* name length (not including padding) */
+    .long 3f - 2f              /* desc length (not including padding) */
+    .long 1                    /* type = NT_VERSION */
+0:  .asciz "my-version-1" /* name */
+1:  .align 4
+2:  .long 1                    /* desc - toolchain version number, 32-bit LE */
+3:  .align 4

--- a/tests/contiguous_note_sections.sh
+++ b/tests/contiguous_note_sections.sh
@@ -1,0 +1,6 @@
+#! /bin/sh -e
+
+# Running --set-interpreter on this binary should not produce the following
+# error:
+# patchelf: cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections
+../src/patchelf --set-interpreter ld-linux-x86-64.so.2 contiguous_note_sections


### PR DESCRIPTION
Add a testcase for the following reported alignment issue with contiguous note
sections (#275):

"""
If a binary has multiple SHT_NOTE sections and corresponding PT_NOTE
headers, we can see the error:

patchelf: cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections

if the SHT_NOTE sections aren't sized to end on aligned boundaries. An example
would be a binary with:

[ 2] .note.ABI-tag NOTE 00000000000002f4 000002f4
0000000000000020 0000000000000000 A 0 0 4
[ 3] .note.gnu.propert NOTE 0000000000000318 00000318
0000000000000030 0000000000000000 A 0 0 8
[ 4] .note.gnu.build-i NOTE 0000000000000348 00000348
0000000000000024 0000000000000000 A 0 0 4

NOTE 0x0000000000000318 0x0000000000000318 0x0000000000000318
0x0000000000000030 0x0000000000000030 R 0x8
NOTE 0x00000000000002f4 0x00000000000002f4 0x00000000000002f4
0x0000000000000078 0x0000000000000074 R 0x4

since the PT_NOTE section at 2f4 covers [2] and [3] but the code
calclates curr_off should be 314, not the 318 in the binary. This
is an alignment issue.
"""

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be perserved.
