### PR TITLE
addNeeded: fix assertion triggered due to bad .dynstr section resize 

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1592,12 +1592,15 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
     auto shdrDynamic = findSection(".dynamic");
     auto shdrDynStr = findSection(".dynstr");
 
+    unsigned int length = 0;
+
     /* add all new libs to the dynstr string table */
-    unsigned int length = std::count_if(libs.begin(), libs.end(),
-        [](const std::string & lib) { return lib.size() + 1; });
+    for (auto &lib : libs)
+        length += lib.size() + 1;
 
     std::string & newDynStr = replaceSection(".dynstr",
         rdi(shdrDynStr.sh_size) + length + 1);
+
     std::set<Elf64_Xword> libStrings;
     unsigned int pos = 0;
     for (auto & i : libs) {

--- a/tests/plain-needed.sh
+++ b/tests/plain-needed.sh
@@ -1,4 +1,25 @@
 #! /bin/sh
 set -e
+
+SCRATCH=scratch/$(basename $0 .sh)
+MAIN_ELF="${SCRATCH}/main"
+
+PATCHELF="../src/patchelf"
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+cp main ${SCRATCH}/
+
 echo "Confirming main requires libfoo"
-../src/patchelf --print-needed main | grep -q libfoo.so
+${PATCHELF} --print-needed "${MAIN_ELF}" | grep -q libfoo.so
+
+echo "Testing --add-needed functionality"
+${PATCHELF} --add-needed bar.so "${MAIN_ELF}"
+${PATCHELF} --print-needed "${MAIN_ELF}" | grep -q bar.so
+
+echo "Testing --remove-needed functionality"
+${PATCHELF} --remove-needed bar.so "${MAIN_ELF}"
+if ${PATCHELF} --print-needed "${MAIN_ELF}" | grep -q bar.so; then
+	echo "ERROR: --remove-needed did not eliminate bar.so!"
+	exit 1
+fi


### PR DESCRIPTION
When running "--add-needed" subcommand on a hello world binary, the
following assertion is triggered:
"""
$ echo "int main() {}" | gcc -xc -o test -
$ patchelf --add-needed foo.so --output /dev/null test
patching ELF file 'scratch/plain-needed/main'
patchelf: patchelf.cc:1167: void setSubstr(std::string&, unsigned int, const string&): Assertion `pos + t.size() <= s.size()' failed.
Aborted (core dumped)
"""

This is due to the fact that .dynstr section is resized incorrectly:
"""
    unsigned int length = std::count_if(libs.begin(), libs.end(),
        [](const std::string & lib) { return lib.size() + 1; });
"""

std::count_if() will return the number of strings in std::set<std::string> libs
(e.g. 1 in the foo.so example). However, in order to properly resize the
.dynstr section, subsequent code expects the size (in bytes) of all the strings
that are to be appended:
"""
    std::string & newDynStr = replaceSection(".dynstr",
        rdi(shdrDynStr.sh_size) + length + 1);
"""

To fix this, iterate over "libs" and compute the length of all the strings that
need to be added to the .dynstr section.

Fixes #291.

Fixes: fce77b7 ("replace for loop with any_of")
Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>
