### PR TITLE
tests/contiguous_note_sections.s: use alternate section type prefix

### DIFF
--- a/tests/contiguous_note_sections.s
+++ b/tests/contiguous_note_sections.s
@@ -2,7 +2,7 @@
  * Testcase for error:
  * patchelf: cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections
  */
-.section ".note.my-section0", "a", @note
+.section ".note.my-section0", "a", %note
     .align 4
     .long 1f - 0f              /* name length (not including padding) */
     .long 3f - 2f              /* desc length (not including padding) */
@@ -12,7 +12,7 @@
 2:  .long 1                    /* desc - toolchain version number, 32-bit LE */
 3:  .align 4
 
-.section ".note.my-section1", "a", @note
+.section ".note.my-section1", "a", %note
     .align 8
     .long 1f - 0f              /* name length (not including padding) */
     .long 3f - 2f              /* desc length (not including padding) */


### PR DESCRIPTION
Fixes #294

Testcase `contiguous_note_sections.sh` passes cross compiled on `armv7l-hf-multiplatform`, should ideally be verified on native ARMv6/7.

cc @jeremysanders @ovpanait 