### PR TITLE
define default PACKAGE_STRING

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -40,6 +40,9 @@
 
 #include "elf.h"
 
+#ifndef PACKAGE_STRING                          \
+#define PACKAGE_STRING "patchelf"
+#endif
 
 static bool debugMode = false;
 


### PR DESCRIPTION
This allows to build patchelf without build system.
Fixes https://github.com/NixOS/patchelf/pull/114 and https://github.com/NixOS/patchelf/issues/102
