### PR TITLE
 Don't try to parse .dynamic section of type NOBITS + test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Makefile
 /tests/too-many-strtab
 /tests/big-dynstr*
 /tests/main-scoped
+/tests/libbig-dynstr.debug

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1025,6 +1025,7 @@ void ElfFile<ElfFileParamNames>::normalizeNoteSegments()
         [this](std::pair<const std::string, std::string> & i) { return rdi(findSection(i.first).sh_type) == SHT_NOTE; });
     if (!replaced_note) return;
 
+    std::vector<Elf_Phdr> newPhdrs;
     for (auto & phdr : phdrs) {
         if (rdi(phdr.p_type) != PT_NOTE) continue;
 
@@ -1061,11 +1062,13 @@ void ElfFile<ElfFileParamNames>::normalizeNoteSegments()
             if (curr_off == start_off)
                 phdr = new_phdr;
             else
-                phdrs.push_back(new_phdr);
+                newPhdrs.push_back(new_phdr);
 
             curr_off += size;
         }
     }
+    phdrs.insert(phdrs.end(), newPhdrs.begin(), newPhdrs.end());
+
     wri(hdr->e_phnum, phdrs.size());
 }
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1330,6 +1330,11 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
 {
     auto shdrDynamic = findSection(".dynamic");
 
+    if (rdi(shdrDynamic.sh_type) == SHT_NOBITS) {
+            debug("no dynamic section\n");
+            return;
+    }
+
     /* !!! We assume that the virtual address in the DT_STRTAB entry
        of the dynamic section corresponds to the .dynstr section. */
     auto shdrDynStr = findSection(".dynstr");

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,7 @@
 LIBS =
 
+STRIP ?= strip
+
 check_PROGRAMS = simple main too-many-strtab main-scoped big-dynstr no-rpath contiguous-note-sections
 
 no_rpath_arch_TESTS = \
@@ -32,7 +34,8 @@ src_TESTS = \
   invalid-elf.sh \
   endianness.sh \
   contiguous-note-sections.sh \
-  no-gnu-hash.sh
+  no-gnu-hash.sh \
+  no-dynamic-section.sh
 
 build_TESTS = \
   $(no_rpath_arch_TESTS)
@@ -73,12 +76,22 @@ main_scoped_LDFLAGS = $(LDFLAGS_local)
 
 big-dynstr.c: main.c
 	cat $< > big-dynstr.c
-	for i in $$(seq 1 2000); do echo "void f$$i(void) { };" >> big-dynstr.c; done
+	for i in $$(seq 1 2000); do echo "void f$$i(void) { };"; done >> big-dynstr.c
 
 nodist_big_dynstr_SOURCES = big-dynstr.c
 big_dynstr_LDADD = -lfoo $(AM_LDADD)
 big_dynstr_DEPENDENCIES = libfoo.so
 big_dynstr_LDFLAGS = $(LDFLAGS_local)
+
+# somehow bug does not trigger if we use
+# normal autotools rules to build the program:
+# https://github.com/NixOS/patchelf/pull/303
+libbig-dynstr.so: big-dynstr.c
+	$(CC) -fPIC -shared -o $@ $<
+libbig-dynstr.debug: libbig-dynstr.so
+	$(STRIP) --only-keep-debug libbig-dynstr.so -o libbig-dynstr.debug
+check_DATA = libbig-dynstr.debug
+
 
 # declare local shared libraries as programs as:
 # - without libtool, only archives (static libraries) can be built by automake

--- a/tests/no-dynamic-section.sh
+++ b/tests/no-dynamic-section.sh
@@ -1,0 +1,4 @@
+#! /bin/sh -e
+
+# print rpath on library with stripped dynamic section
+../src/patchelf --print-rpath libbig-dynstr.debug


### PR DESCRIPTION
Basically https://github.com/NixOS/patchelf/pull/303 with a failing test
also includes https://github.com/NixOS/patchelf/pull/302 since it fixes address sanitizer