### PR TITLE
add undefined behavior sanitizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Makefile
 /tests/big-dynstr*
 /tests/main-scoped
 /tests/libbig-dynstr.debug
+/tests/contiguous-note-sections

--- a/configure.ac
+++ b/configure.ac
@@ -20,9 +20,14 @@ if test "$DEFAULT_PAGESIZE" != auto; then
 fi
 
 AC_ARG_WITH([asan],
-   AS_HELP_STRING([--with-asan], [Link with libasan])
+   AS_HELP_STRING([--with-asan], [Build with address sanitizer])
 )
 AM_CONDITIONAL([WITH_ASAN], [test x"$with_asan" = xyes])
+
+AC_ARG_WITH([ubsan],
+   AS_HELP_STRING([--with-ubsan], [Build with undefined behavior sanitizer])
+)
+AM_CONDITIONAL([WITH_UBSAN], [test x"$with_ubsan" = xyes])
 
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile patchelf.spec])
 AC_OUTPUT

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,9 @@
           };
 
         build = forAllSystems (system: nixpkgsFor.${system}.patchelf-new);
+        build-sanitized = forAllSystems (system: nixpkgsFor.${system}.patchelf-new.overrideAttrs (old: {
+          configureFlags = [ "--with-asan " "--with-ubsan" ];
+        }));
 
         release = pkgs.releaseTools.aggregate
           { name = "patchelf-${self.hydraJobs.tarball.version}";
@@ -65,6 +68,8 @@
               [ self.hydraJobs.tarball
                 self.hydraJobs.build.x86_64-linux
                 self.hydraJobs.build.i686-linux
+                self.hydraJobs.build-sanitized.x86_64-linux
+                self.hydraJobs.build-sanitized.i686-linux
               ];
             meta.description = "Release-critical builds";
           };

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,13 @@
 AM_CXXFLAGS = -Wall -std=c++11 -D_FILE_OFFSET_BITS=64
 
+SAN_FLAGS = -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1
+
 if WITH_ASAN
-AM_CXXFLAGS += -fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1
+AM_CXXFLAGS += -fsanitize=address $(SAN_FLAGS)
+endif
+
+if WITH_UBSAN
+AM_CXXFLAGS += -fsanitize=undefined $(SAN_FLAGS)
 endif
 
 bin_PROGRAMS = patchelf

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,13 +1,20 @@
 AM_CXXFLAGS = -Wall -std=c++11 -D_FILE_OFFSET_BITS=64
 
-SAN_FLAGS = -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1
-
 if WITH_ASAN
-AM_CXXFLAGS += -fsanitize=address $(SAN_FLAGS)
+AM_CXXFLAGS += -fsanitize=address -fsanitize-address-use-after-scope
 endif
 
 if WITH_UBSAN
-AM_CXXFLAGS += -fsanitize=undefined $(SAN_FLAGS)
+AM_CXXFLAGS += -fsanitize=undefined
+endif
+
+SAN_FLAGS = -fno-optimize-sibling-calls -fno-omit-frame-pointer
+if WITH_ASAN
+AM_CXXFLAGS += $(SAN_FLAGS)
+else
+if WITH_UBSAN
+AM_CXXFLAGS += $(SAN_FLAGS)
+endif
 endif
 
 bin_PROGRAMS = patchelf


### PR DESCRIPTION
in addition to address sanitizer the undefined behavior sanitizer also catches bugs like integer overflows.