### PR TITLE
configure.ac: add check for strip

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,8 @@ AC_CONFIG_SRCDIR([src/patchelf.cc])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([1.11.1 -Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
 
+AC_CHECK_TOOL([STRIP], [strip])
+
 AM_PROG_CC_C_O
 AC_PROG_CXX
 AM_PROG_AS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,5 @@
 LIBS =
 
-STRIP ?= strip
-
 check_PROGRAMS = simple-pie simple main too-many-strtab main-scoped big-dynstr no-rpath contiguous-note-sections
 
 no_rpath_arch_TESTS = \


### PR DESCRIPTION
Currently, "make check" fails on Ubuntu 20.04 because the STRIP variable is not
set in the resulting tests/Makefile:
```sh
"""
git clone https://github.com/NixOS/patchelf.git
./bootstrap.sh
./configure
make VERBOSE=1 check
...
gcc -fPIC -shared -o libbig-dynstr.so big-dynstr.c
only-keep-debug libbig-dynstr.so -o libbig-dynstr.debug
/bin/bash: only-keep-debug: command not found
make[2]: [Makefile:1526: libbig-dynstr.debug] Error 127 (ignored)
...
FAIL: no-dynamic-section.sh
===========================

patchelf: getting info about 'libbig-dynstr.debug': No such file or directory
FAIL no-dynamic-section.sh (exit status: 1)
"""
```

strip is used by the regression testsuite, so add a check for it configure.ac.

Signed-off-by: Ovidiu Panait <ovpanait@gmail.com>

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
