### PR TITLE
Fix build-sanitized-clang.aarch64-linux build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1628523294,
-        "narHash": "sha256-qMkH/JRRmcqb/eOa/pKksrKGOy2YEPQNH/457QyoyFg=",
+        "lastModified": 1637875414,
+        "narHash": "sha256-Ica++SXFuLyxX9Q7YxhfZulUif6/gwM8AEQYlUxqSgE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b09c989b82f7a4f7319802a1dcf8bfe859d65362",
+        "rev": "3bea86e918d8b54aa49780505d2d4cd9261413be",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,11 +44,16 @@
           };
 
         coverage =
-          pkgs.releaseTools.coverageAnalysis {
+          (pkgs.releaseTools.coverageAnalysis {
             name = "patchelf-coverage";
             src = self.hydraJobs.tarball;
             lcovFilter = ["*/tests/*"];
-          };
+          }).overrideAttrs (old: {
+            preCheck = ''
+              # coverage cflag breaks this target
+              NIX_CFLAGS_COMPILE=''${NIX_CFLAGS_COMPILE//--coverage} make -C tests phdr-corruption.so
+            '';
+          });
 
         build = forAllSystems (system: nixpkgsFor.${system}.patchelf-new);
         build-sanitized = forAllSystems (system: nixpkgsFor.${system}.patchelf-new.overrideAttrs (old: {

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
           CFLAGS = "-Werror -Wno-unused-command-line-argument";
         }));
         build-sanitized-clang = forAllSystems (system: self.hydraJobs.build-sanitized.${system}.override {
-          stdenv = pkgs.libcxxStdenv;
+          stdenv = nixpkgsFor.${system}.libcxxStdenv;
         });
 
         release = pkgs.releaseTools.aggregate

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,8 @@
           # our cc wrapper arguments
           CFLAGS = "-Werror -Wno-unused-command-line-argument";
         }));
-        build-sanitized-clang = forAllSystems (system: self.hydraJobs.build-sanitized.${system}.override {
+        # 32-bit clangStdenv seems broken in nixpkgs
+        build-sanitized-clang = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ] (system: self.hydraJobs.build-sanitized.${system}.override {
           stdenv = nixpkgsFor.${system}.libcxxStdenv;
         });
 
@@ -75,7 +76,6 @@
                 self.hydraJobs.build-sanitized.x86_64-linux
                 self.hydraJobs.build-sanitized.i686-linux
                 self.hydraJobs.build-sanitized-clang.x86_64-linux
-                self.hydraJobs.build-sanitized-clang.i686-linux
               ];
             meta.description = "Release-critical builds";
           };


### PR DESCRIPTION
We were passing stdenv for the wrong architecture