### PR TITLE
ci: split building & publishing tarballs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,17 @@
 name: Publish
 on:
+  workflow_dispatch:
+  pull_request:
   push:
+    branches:
+      - master
+      - main
     tags:
       - '*'
 
 jobs:
-  build:
-    name: Publish tarballs
+  build_tarballs:
+    name: Build tarballs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,6 +22,21 @@ jobs:
           nix-build -A hydraJobs.tarball
           install -D ./result/tarballs/*.tar.bz2 ./dist/patchelf-$(cat version).tar.bz2
           install -D ./result/tarballs/*.tar.gz ./dist/patchelf-$(cat version).tar.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: patchelf
+          path: dist/*
+
+  publish:
+    name: Publish tarballs
+    needs: [build_tarballs]
+    if: github.event_name == 'push' && github.repository == 'NixOS/patchelf' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: patchelf
+          path: dist
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
This allows testing the tarball builds on each commit.
