### PR TITLE
Add build & test of static musl binaries to the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,15 @@
 name: Publish
 on:
+  pull_request:
   push:
+    branches:
+      - '*'
     tags:
       - '*'
 
 jobs:
-  build:
-    name: Publish tarballs
+  build_tarballs:
+    name: Build tarballs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,6 +20,21 @@ jobs:
           nix-build -A hydraJobs.tarball
           install -D ./result/tarballs/*.tar.bz2 ./dist/patchelf-$(cat version).tar.bz2
           install -D ./result/tarballs/*.tar.gz ./dist/patchelf-$(cat version).tar.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: patchelf
+          path: dist/*
+
+  publish:
+    name: Publish tarballs
+    needs: [build_tarballs]
+    if: github.event_name == 'push' && github.repository == 'NixOS/patchelf' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: patchelf
+          path: dist
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,64 @@ jobs:
           name: patchelf
           path: dist/*
 
-  publish:
-    name: Publish tarballs
+  build_binaries:
+    name: Build static musl binaries
     needs: [build_tarballs]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ["amd64", "i386", "ppc64le", "arm64v8", "arm32v7", "s390x"]
+    steps:
+      - name: Set up QEMU
+        if: matrix.platform != 'amd64'
+        uses: docker/setup-qemu-action@v1
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: patchelf
+          path: dist
+      - name: Build binaries
+        env:
+          CXXFLAGS: "-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wformat -Werror=format-security -O2 -static"
+        run: |
+          cat <<EOF > build.sh
+          set -e
+          set -x
+          apk add build-base
+          tar -xf dist/*.tar.bz2
+          rm -f dist/*
+          cd patchelf-*
+          ./configure --prefix /patchelf
+          make check
+          make install-strip
+          cd -
+          tar -czf ./dist/patchelf-\$(cat patchelf-*/version)-\$(uname -m).tar.gz -C /patchelf .
+          EOF
+
+          if [ "${{ matrix.platform }}" == "i386" ]; then
+              ENTRYPOINT=linux32
+          else
+              ENTRYPOINT=
+          fi
+          docker run -e CXXFLAGS -v $(pwd):/gha ${{ matrix.platform }}/alpine:3.15 ${ENTRYPOINT} sh -ec "cd /gha && sh ./build.sh"
+      - name: Check binaries
+        run: |
+          cat <<EOF > check.sh
+          set -e
+          set -x
+          tar -xf ./dist/patchelf-*-*.tar.gz
+          ./bin/patchelf --version
+          EOF
+          docker run -v $(pwd):/gha ${{ matrix.platform }}/debian:stable-slim sh -ec "cd /gha && sh ./check.sh"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: patchelf
+          path: dist/*
+
+  publish:
+    name: Publish tarballs & binaries
+    needs: [build_tarballs, build_binaries]
     if: github.event_name == 'push' && github.repository == 'NixOS/patchelf' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This adds build & test of static musl binaries to the publish workflow.

fixes #330