### PR TITLE
Use correct double-dashes for ld(1)'s build-id option

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -108,7 +108,7 @@ check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimpl
                   phdr-corruption.so
 
 libbuildid_so_SOURCES = simple.c
-libbuildid_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-build-id
+libbuildid_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,--build-id
 
 libfoo_so_SOURCES = foo.c
 libfoo_so_LDADD = -lbar $(AM_LDADD)


### PR DESCRIPTION
(Old) linkers such as BFD's ld(1) aka. GNU ld (version 2.17 on OpenBSD)
don't know `--build-id`, but they know `-b input-format` which patchelf
triggers by ommitting the second dash.

LLD's ld(1) seems to cope with this, although it's incorrect usage.

Use the double dash for correctness to get accurate error messages with
such incompatible linkers:

	-/usr/bin/ld: invalid BFD target `uild-id'
	+/usr/bin/ld: unrecognized option '--build-id'
	+/usr/bin/ld: use the --help option for usage information

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
