### PR TITLE
Use absoloute paths to linker scripts

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -137,9 +137,9 @@ no_rpath_SOURCES = no-rpath.c
 no_rpath_CFLAGS =
 
 contiguous_note_sections_SOURCES = contiguous-note-sections.s contiguous-note-sections.ld
-contiguous_note_sections_LDFLAGS = -nostdlib -T contiguous-note-sections.ld
+contiguous_note_sections_LDFLAGS = -nostdlib -T $(srcdir)/contiguous-note-sections.ld
 contiguous_note_sections_CFLAGS = -pie
 
 phdr_corruption_so_SOURCES = void.c phdr-corruption.ld
-phdr_corruption_so_LDFLAGS = -nostdlib -shared -Wl,-Tphdr-corruption.ld
+phdr_corruption_so_LDFLAGS = -nostdlib -shared -Wl,-T$(srcdir)/phdr-corruption.ld
 phdr_corruption_so_CFLAGS =


### PR DESCRIPTION
As is common with autotools enabled software, building and testing
happens outside the source directory.

The introduction of `contiguous-note-sections` test in 0.13 broke this
by assuming linker scripts to exist in the current working directory.

Point at the absoloute source directory explicitly to unbreak linking in
such build environments.

Spotted on OpenBSD where source and build assets are commonly
separated iff possible.
