### PR TITLE
Avoid GNU seq(1)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -83,7 +83,7 @@ main_scoped_LDFLAGS = $(LDFLAGS_local)
 
 big-dynstr.c: main.c
 	cat $< > big-dynstr.c
-	for i in $$(seq 1 2000); do echo "void f$$i(void) { };"; done >> big-dynstr.c
+	i=1; while [ $$i -le 2000 ]; do echo "void f$$i(void) { };"; i=$$(($$i + 1)); done >> big-dynstr.c
 
 nodist_big_dynstr_SOURCES = big-dynstr.c
 big_dynstr_LDADD = -lfoo $(AM_LDADD)


### PR DESCRIPTION
MacOS, FreeBSD and Linux using GNU have it, but at least OpenBSD
does not (the non-compatible BSD equivalent jot(1) exists, though).

Counting up is easy enough to do in POSIX sh(1).

Looks like this after GNU make(1)'s escaping and produces the same
big-dynstr.c file:
```
cat main.c > big-dynstr.c
i=1; while [ $i -le 2000 ]; do echo "void f$i(void) { };"; i=$(($i + 1)); done >> big-dynstr.c
```

This is the last bit required to build and pass all tests on OpenBSD
without local patches/dependencies.

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
