### PR TITLE
print-interpreter: fix off by one error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ Makefile
 /tests/libbig-dynstr.debug
 /tests/contiguous-note-sections
 /tests/simple-pie
+
+.direnv/
+.vscode/
+.idea/

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1237,7 +1237,7 @@ template<ElfFileParams>
 std::string ElfFile<ElfFileParamNames>::getInterpreter()
 {
     auto shdr = findSection(".interp");
-    return std::string((char *) fileContents->data() + rdi(shdr.sh_offset), rdi(shdr.sh_size));
+    return std::string((char *) fileContents->data() + rdi(shdr.sh_offset), rdi(shdr.sh_size) - 1);
 }
 
 template<ElfFileParams>


### PR DESCRIPTION
Fix off by one error in the code that reads interpreter from the ELF file. 

This was not evident when it was written directly to STDOUT but became problematic through my exploration of new functionality (#357) since there was an additional '\0' and the strings would not concatenate as a result.

```bash
> ./src/patchelf --print-interpreter /tmp/ruby
/nix/store/563528481rvhc5kxwipjmg6rqrl95mdx-glibc-2.33-56/lib/ld-linux-x86-64.so.2
```

I would love to add a test here to demonstrate the additional '\0', if there is a TODO issue for a test suite please link this issue to it.

CC @Mic92 