### PR TITLE
Allow multiple modifications in same call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Makefile
 .direnv/
 .vscode/
 .idea/
+result

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/p5zbzmcvkgbqldf8g5zsla0xhdf8w2yg-patchelf-0.14.3

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/p5zbzmcvkgbqldf8g5zsla0xhdf8w2yg-patchelf-0.14.3

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1878,10 +1878,22 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, con
 
     if (printNeeded) elfFile.printNeededLibs();
 
-    elfFile.removeNeeded(neededLibsToRemove);
-    elfFile.replaceNeeded(neededLibsToReplace);
-    elfFile.addNeeded(neededLibsToAdd);
-    elfFile.clearSymbolVersions(symbolsToClearVersion);
+    if (!neededLibsToRemove.empty()) {
+        elfFile.removeNeeded(neededLibsToRemove);
+        elfFile.rewriteSections();
+    }
+    if (!neededLibsToReplace.empty()) {
+        elfFile.replaceNeeded(neededLibsToReplace);
+        elfFile.rewriteSections();
+    }
+    if (!neededLibsToAdd.empty()) {
+        elfFile.addNeeded(neededLibsToAdd);
+        elfFile.rewriteSections();
+    }
+    if (!symbolsToClearVersion.empty()) {
+        elfFile.clearSymbolVersions(symbolsToClearVersion);
+        elfFile.rewriteSections();
+    }
 
     if (noDefaultLib)
         elfFile.noDefaultLib();

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,7 +39,8 @@ src_TESTS = \
   basic-flags.sh \
   set-empty-rpath.sh \
   phdr-corruption.sh \
-  replace-needed.sh
+  replace-needed.sh \
+  replace-add-needed.sh
 
 build_TESTS = \
   $(no_rpath_arch_TESTS)

--- a/tests/replace-add-needed.sh
+++ b/tests/replace-add-needed.sh
@@ -1,0 +1,34 @@
+#! /bin/sh -e
+SCRATCH=scratch/$(basename $0 .sh)
+PATCHELF=$(readlink -f "../src/patchelf")
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+
+cp simple ${SCRATCH}/
+cp libfoo.so ${SCRATCH}/
+cp libbar.so ${SCRATCH}/
+
+
+cd ${SCRATCH}
+
+libcldd=$(ldd ./simple | grep -oP "(?<=libc.so.6 => )[^ ]+")
+
+# We have to set the soname on these libraries
+${PATCHELF} --set-soname libbar.so ./libbar.so
+
+# Add a libbar.so so we can rewrite it later
+${PATCHELF} --add-needed libbar.so ./simple
+
+${PATCHELF} --replace-needed libc.so.6 ${libcldd} \
+            --replace-needed libbar.so $(readlink -f ./libbar.so) \
+            --add-needed $(readlink -f ./libfoo.so) \
+            ./simple
+
+exitCode=0
+./simple || exitCode=$?
+
+if test "$exitCode" != 0; then
+    ldd ./simple
+    exit 1
+fi

--- a/tests/replace-add-needed.sh
+++ b/tests/replace-add-needed.sh
@@ -9,16 +9,20 @@ cp simple ${SCRATCH}/
 cp libfoo.so ${SCRATCH}/
 cp libbar.so ${SCRATCH}/
 
-
 cd ${SCRATCH}
 
-libcldd=$(ldd ./simple | awk '/ => / { print $3 }' | grep .so | head -n 1)
+libcldd=$(ldd ./simple | awk '/ => / { print $3 }' | grep -E "(libc.so|ld-musl)")
 
 # We have to set the soname on these libraries
 ${PATCHELF} --set-soname libbar.so ./libbar.so
 
 # Add a libbar.so so we can rewrite it later
 ${PATCHELF} --add-needed libbar.so ./simple
+
+# Make the NEEDED in libfoo the same as simple
+# This is a current "bug" in musl
+# https://www.openwall.com/lists/musl/2021/12/21/1
+${PATCHELF} --replace-needed libbar.so $(readlink -f ./libbar.so) ./libfoo.so
 
 ${PATCHELF} --replace-needed libc.so.6 ${libcldd} \
             --replace-needed libbar.so $(readlink -f ./libbar.so) \

--- a/tests/replace-add-needed.sh
+++ b/tests/replace-add-needed.sh
@@ -12,7 +12,7 @@ cp libbar.so ${SCRATCH}/
 
 cd ${SCRATCH}
 
-libcldd=$(ldd ./simple | grep -oP "(?<=libc.so.6 => )[^ ]+")
+libcldd=$(ldd ./simple | awk '/ => / { print $3 }' | grep .so | head -n 1)
 
 # We have to set the soname on these libraries
 ${PATCHELF} --set-soname libbar.so ./libbar.so


### PR DESCRIPTION
`patchelf` previously would incorrectly patch the ELF header if it was called with multiple changes at once such as _add_ & _replace_.

In order to support that, rewrite the sections in between each section modification.

Please see the issue for the bug and here is now the fix:
```
> ./src/patchelf --replace-needed libruby-2.7.so.2.7 /lib/x86_64-linux-gnu/libruby-2.7.so.2.7 \
--replace-needed libc.so.6 /lib/x86_64-linux-gnu/libc.so.6 \
--add-needed /lib/x86_64-linux-gnu/libcrypt.so.1 \
--add-needed /lib/x86_64-linux-gnu/libdl.so.2 \
--add-needed /lib/x86_64-linux-gnu/libgmp.so.10 \
--add-needed /lib/x86_64-linux-gnu/libm.so.6 \
--add-needed /lib/x86_64-linux-gnu/libpthread.so.0 \
--add-needed /lib/x86_64-linux-gnu/librt.so.1 /tmp/ruby

> ./src/patchelf --print-needed /tmp/ruby
/lib/x86_64-linux-gnu/libcrypt.so.1
/lib/x86_64-linux-gnu/libdl.so.2
/lib/x86_64-linux-gnu/libgmp.so.10
/lib/x86_64-linux-gnu/libm.so.6
/lib/x86_64-linux-gnu/libpthread.so.0
/lib/x86_64-linux-gnu/librt.so.1
/lib/x86_64-linux-gnu/libruby-2.7.so.2.7
/lib/x86_64-linux-gnu/libc.so.6
```

Fix #359

Thank you @trws for the idea of the fix.

CC @Mic92 