### PR TITLE
Add support to build with musl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Makefile
 .direnv/
 .vscode/
 .idea/
+result

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ libraries.  In particular, it can do the following:
 
 ## Compiling and Testing
 
+### Via Autotools
 ```console
 ./bootstrap.sh
 ./configure
@@ -77,6 +78,13 @@ make
 make check
 sudo make install
 ```
+### Via Nix
+
+You can build with Nix in several ways.
+
+1. Building via `nix build` will produce the result in `./result/bin/patchelf`. If you would like to build _patchelf_ with _musl_ try `nix build .#patchelf-musl`
+
+2. You can launch a development environment with `nix develop` and folllow the autotools steps above. If you would like to develop with _musl_ try `nix develop .#musl`
 
 ## Author
 

--- a/flake.nix
+++ b/flake.nix
@@ -93,12 +93,8 @@
 
       devShells = forAllSystems (system:
         {
-          glibc = pkgs.mkShell {
-            buildInputs = [ self.packages.${system}.patchelf.inputDerivation];
-          };
-          musl = pkgs.pkgsMusl.mkShell {
-            buildInputs = [ self.packages.${system}.patchelf-musl.inputDerivation];
-          };
+          glibc = self.packages.${system}.patchelf;
+          musl = self.packages.${system}.patchelf-musl;
         });
 
       defaultPackage = forAllSystems (system:

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,10 @@
 
     {
       overlay = final: prev: {
+        patchelf-new-musl = final.pkgsMusl.callPackage ./patchelf.nix {
+          inherit version;
+          src = self;
+        };
         patchelf-new = final.callPackage ./patchelf.nix {
           inherit version;
           src = self;
@@ -85,12 +89,19 @@
         build = self.hydraJobs.build.${system};
       });
 
+      devShell = forAllSystems (system: pkgs.mkShell {
+          buildInputs = [ self.defaultPackage.${system}.inputDerivation];
+      });
+
       defaultPackage = forAllSystems (system:
-        (import nixpkgs {
-          inherit system;
-          overlays = [ self.overlay ];
-        }).patchelf-new
+        self.packages.${system}.patchelf
       );
+
+      packages = forAllSystems (system:
+        {
+          patchelf = nixpkgsFor.${system}.patchelf-new;
+          patchelf-musl = nixpkgsFor.${system}.patchelf-new-musl;
+        });
 
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -89,9 +89,17 @@
         build = self.hydraJobs.build.${system};
       });
 
-      devShell = forAllSystems (system: pkgs.mkShell {
-          buildInputs = [ self.defaultPackage.${system}.inputDerivation];
-      });
+      devShell = forAllSystems (system: self.devShells.${system}.glibc);
+
+      devShells = forAllSystems (system:
+        {
+          glibc = pkgs.mkShell {
+            buildInputs = [ self.packages.${system}.patchelf.inputDerivation];
+          };
+          musl = pkgs.pkgsMusl.mkShell {
+            buildInputs = [ self.packages.${system}.patchelf-musl.inputDerivation];
+          };
+        });
 
       defaultPackage = forAllSystems (system:
         self.packages.${system}.patchelf


### PR DESCRIPTION
Add support to the flake.nix to build with musl

```
nix build .#patchelf-musl

ld-musl-x86_64.so.1 --list ./result/bin/patchelf
	/nix/store/2lp9hm9idb2y8zxfqi4nnvxsrk4vym6d-musl-1.2.2/lib/ld-musl-x86_64.so.1 (0x7fc3d791d000)
	libstdc++.so.6 => /nix/store/b29ihq5w7rh1qga809bxsdrh2mrrvd7m-gcc-10.3.0-lib/lib/libstdc++.so.6 (0x7fc3d76f7000)
	libgcc_s.so.1 => /nix/store/b29ihq5w7rh1qga809bxsdrh2mrrvd7m-gcc-10.3.0-lib/lib/libgcc_s.so.1 (0x7fc3d76dd000)
	libc.so => /nix/store/2lp9hm9idb2y8zxfqi4nnvxsrk4vym6d-musl-1.2.2/lib/ld-musl-x86_64.so.1 (0x7fc3d791d000)

./result/bin/patchelf --help
syntax: ./result/bin/patchelf
  [--set-interpreter FILENAME]
...
```

You can also launch a _develop_ shell for **glib** and **musl**.

CC @Mic92 