### PR TITLE
Introduce Finally to help track section rewrites

### DIFF
--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -1,3 +1,15 @@
+#pragma once
+
+#include <string>
+#include <functional>
+#include <vector>
+#include <optional>
+#include <map>
+#include <set>
+#include <memory>
+
+#include "elf.h"
+
 using FileContents = std::shared_ptr<std::vector<unsigned char>>;
 
 #define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed, class Elf_Versym
@@ -157,3 +169,15 @@ private:
       return (const Elf_Ehdr *)fileContents->data();
     }
 };
+
+/* A trivial class to run a function at the end of a scope. */
+class Finally
+{
+private:
+    std::function<void()> fun;
+
+public:
+    Finally(std::function<void()> fun) : fun(fun) { }
+    ~Finally() { fun(); }
+};
+


### PR DESCRIPTION
Similarly to a concept used in NixOS/nix codebase, introduce the `Finally` class that can be given a lambda to execute on destructor.

The desired effect is to execute some code on a scope leave, in this case the method return.

This is used to make sure we only apply `sectionRewrite` once per modification and can now support early returns in the code paths.

CC @reidpr