### PR TITLE
fix incorrect polarity on dyn_offset; closes #364

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1021,7 +1021,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
                 if (shdr) {
                     auto rld_map_addr = findSectionHeader(".rld_map").sh_addr;
                     auto dyn_offset = ((char*)dyn) - ((char*)dyn_table);
-                    dyn->d_un.d_ptr = rld_map_addr + dyn_offset - (*shdrDynamic).get().sh_addr;
+                    dyn->d_un.d_ptr = rld_map_addr - dyn_offset - (*shdrDynamic).get().sh_addr;
                 } else {
                     /* ELF file with DT_MIPS_RLD_MAP_REL but without .rld_map
                        is broken, and it's not our job to fix it; yet, we have


### PR DESCRIPTION
This fixes #364 and I have verified that --set-interpreter now works correctly on mips64el-linux-gnuabin32.

However --set-rpath is still broken (produces corrupted binaries); fortunately for that task `chrpath` can be used instead (it works properly).
