### PR TITLE
Add --add-debug option

### DIFF
--- a/patchelf.1
+++ b/patchelf.1
@@ -89,6 +89,13 @@ option can be given multiple times.
 Marks the object so that the search for dependencies of this object will ignore any
 default library search paths.
 
+.IP "--add-debug-tag"
+Adds DT_DEBUG tag to the .dynamic section if not yet present in an ELF
+object. A shared library (-shared) by default does not receive DT_DEBUG tag.
+This means that when a shared library has an entry point (so that it
+can be run as an executable), the debugger does not connect to it correctly and
+symbols are not resolved.
+
 .IP "--output FILE"
 Set the output file name.  If not specified, the input will be modified in place.
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1653,7 +1653,7 @@ void ElfFile<ElfFileParamNames>::noDefaultLib()
 }
 
 template<ElfFileParams>
-void ElfFile<ElfFileParamNames>::addDebug()
+void ElfFile<ElfFileParamNames>::addDebugTag()
 {
     auto shdrDynamic = findSectionHeader(".dynamic");
 
@@ -1723,7 +1723,7 @@ static std::vector<std::string> allowedRpathPrefixes;
 static bool removeRPath = false;
 static bool setRPath = false;
 static bool addRPath = false;
-static bool addDebug = false;
+static bool addDebugTag = false;
 static bool printRPath = false;
 static std::string newRPath;
 static std::set<std::string> neededLibsToRemove;
@@ -1770,8 +1770,8 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, con
     if (noDefaultLib)
         elfFile.noDefaultLib();
 
-    if (addDebug)
-        elfFile.addDebug();
+    if (addDebugTag)
+        elfFile.addDebugTag();
 
     if (elfFile.isChanged()){
         writeFile(fileName, elfFile.fileContents);
@@ -1829,7 +1829,7 @@ void showHelp(const std::string & progName)
   [--print-needed]\n\
   [--no-default-lib]\n\
   [--clear-symbol-version SYMBOL]\n\
-  [--add-debug]\n\
+  [--add-debug-tag]\n\
   [--output FILE]\n\
   [--debug]\n\
   [--version]\n\
@@ -1938,8 +1938,8 @@ int mainWrapped(int argc, char * * argv)
         else if (arg == "--no-default-lib") {
             noDefaultLib = true;
         }
-        else if (arg == "--add-debug") {
-            addDebug = true;
+        else if (arg == "--add-debug-tag") {
+            addDebugTag = true;
         }
         else if (arg == "--help" || arg == "-h" ) {
             showHelp(argv[0]);

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -131,7 +131,7 @@ public:
 
     void noDefaultLib();
 
-    void addDebug();
+    void addDebugTag();
 
     void clearSymbolVersions(const std::set<std::string> & syms);
 

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -131,6 +131,8 @@ public:
 
     void noDefaultLib();
 
+    void addDebug();
+
     void clearSymbolVersions(const std::set<std::string> & syms);
 
 private:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,7 +40,8 @@ src_TESTS = \
   set-empty-rpath.sh \
   phdr-corruption.sh \
   replace-needed.sh \
-  replace-add-needed.sh
+  replace-add-needed.sh \
+  add-debug-tag.sh
 
 build_TESTS = \
   $(no_rpath_arch_TESTS)

--- a/tests/add-debug-tag.sh
+++ b/tests/add-debug-tag.sh
@@ -1,0 +1,26 @@
+#! /bin/sh -e
+SCRATCH=scratch/$(basename $0 .sh)
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+
+cp libsimple.so ${SCRATCH}/
+
+# check there is no DT_DEBUG tag
+debugTag=$(readelf -d ${SCRATCH}/libsimple.so)
+echo ".dynamic before: $debugTag"
+if echo "$debugTag" | grep -q DEBUG; then
+    echo "failed --add-debug-tag test. Expected no line with (DEBUG), got: $debugTag"
+    exit 1
+fi
+
+# set DT_DEBUG
+../src/patchelf --add-debug-tag ${SCRATCH}/libsimple.so
+
+# check there is DT_DEBUG tag
+debugTag=$(readelf -d ${SCRATCH}/libsimple.so)
+echo ".dynamic before: $debugTag"
+if ! echo "$debugTag" | grep -q DEBUG; then
+    echo "failed --add-debug-tag test. Expected line with (DEBUG), got: $debugTag"
+    exit 1
+fi


### PR DESCRIPTION
A shared library (-shared) by default does not receive DT_DEBUG tag.
This means that when a shared library has an entry point (so that it
can be run as an executable), the debugger does not connect to it
correctly and symbols are not resolved.

--add-debug option adds DT_DEBUG tag if it not yet present to an ELF
object.

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
