### PR TITLE
Add O_BINARY flag when opening files to allow compilation for Windows

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -47,6 +47,7 @@
 #define PACKAGE_STRING "patchelf"
 #endif
 
+// This is needed for Windows/mingw
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -47,6 +47,10 @@
 #define PACKAGE_STRING "patchelf"
 #endif
 
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 static bool debugMode = false;
 
 static bool forceRPath = false;
@@ -164,7 +168,7 @@ static FileContents readFile(const std::string & fileName,
 
     FileContents contents = std::make_shared<std::vector<unsigned char>>(size);
 
-    int fd = open(fileName.c_str(), O_RDONLY);
+    int fd = open(fileName.c_str(), O_RDONLY | O_BINARY);
     if (fd == -1) throw SysError(fmt("opening '", fileName, "'"));
 
     size_t bytesRead = 0;
@@ -375,7 +379,7 @@ static void writeFile(const std::string & fileName, const FileContents & content
 {
     debug("writing %s\n", fileName.c_str());
 
-    int fd = open(fileName.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0777);
+    int fd = open(fileName.c_str(), O_CREAT | O_TRUNC | O_WRONLY | O_BINARY, 0777);
     if (fd == -1)
         error("open");
 


### PR DESCRIPTION
Hello!

Thank you for maintaining this tool. We've been using it at Guardsquare for a while and have recently identified a use-case where we would also need to run it on Windows hosts.

This could be achieved by switching the compiler to MinGW-w64. However, when opening the ELF file for reading/writing the code currently does not pass the `O_BINARY` flag. If the flag is not passed on Windows, the file is opened in text mode and reading/writing may prematurely end due to misinterpretation of file contents. 

This pull request resolves this issue by:
- Defining `O_BINARY` as `0` if it isn't defined, so that it has no effect on systems that do not have the `O_BINARY` flag.
- Passing `O_BINARY` when opening the ELF file for reading/writing.

Thank you for taking the time to look at this.

Best Regards,
Jago
