### PR TITLE
modifyRPath: return early if new and old rpath are empty

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1350,8 +1350,8 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
     debug("new rpath is '%s'\n", newRPath.c_str());
 
 
-    if (rpath && newRPath.size() <= rpathSize) {
-        memcpy(rpath, newRPath.c_str(), newRPath.size() + 1);
+    if (newRPath.size() <= rpathSize) {
+        if (rpath) memcpy(rpath, newRPath.c_str(), newRPath.size() + 1);
         return;
     }
 


### PR DESCRIPTION
de3901853d49e7a607fc2bcdeb18e33875bce8ce fixed the null dereference but `modifyRPath` should still return early under this condition.

ping @Mic92