### PR TITLE
add --no-sort option

### DIFF
--- a/patchelf.1
+++ b/patchelf.1
@@ -92,6 +92,11 @@ Prints all DT_NEEDED entries of the executable.
 Marks the object so that the search for dependencies of this object will ignore any
 default library search paths.
 
+.IP "--no-sort"
+Do not sort program headers or section headers.  This is useful when
+debugging patchelf, because it makes it easier to read diffs of the
+output of "readelf -a".
+
 .IP "--add-debug-tag"
 Adds DT_DEBUG tag to the .dynamic section if not yet present in an ELF
 object. A shared library (-shared) by default does not receive DT_DEBUG tag.

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -735,14 +735,16 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
     rewriteHeaders(firstPage + rdi(hdr()->e_phoff));
 }
 
+static bool noSort = false;
 
 template<ElfFileParams>
 void ElfFile<ElfFileParamNames>::rewriteSectionsExecutable()
 {
-    /* Sort the sections by offset, otherwise we won't correctly find
-       all the sections before the last replaced section. */
-    sortShdrs();
-
+    if (!noSort) {
+        /* Sort the sections by offset, otherwise we won't correctly find
+           all the sections before the last replaced section. */
+        sortShdrs();
+    }
 
     /* What is the index of the last replaced section? */
     unsigned int lastReplaced = 0;
@@ -955,7 +957,9 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
         }
     }
 
-    sortPhdrs();
+    if (!noSort) {
+        sortPhdrs();
+    }
 
     for (unsigned int i = 0; i < phdrs.size(); ++i)
         * ((Elf_Phdr *) (fileContents->data() + rdi(hdr()->e_phoff)) + i) = phdrs.at(i);
@@ -964,7 +968,9 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
     /* Rewrite the section header table.  For neatness, keep the
        sections sorted. */
     assert(rdi(hdr()->e_shnum) == shdrs.size());
-    sortShdrs();
+    if (!noSort) {
+        sortShdrs();
+    }
     for (unsigned int i = 1; i < rdi(hdr()->e_shnum); ++i)
         * ((Elf_Shdr *) (fileContents->data() + rdi(hdr()->e_shoff)) + i) = shdrs.at(i);
 
@@ -1833,6 +1839,7 @@ void showHelp(const std::string & progName)
   [--replace-needed LIBRARY NEW_LIBRARY]\n\
   [--print-needed]\n\
   [--no-default-lib]\n\
+  [--no-sort]\t\tDo not sort program+section headers; useful for debugging patchelf.\n\
   [--clear-symbol-version SYMBOL]\n\
   [--add-debug-tag]\n\
   [--output FILE]\n\
@@ -1914,6 +1921,9 @@ int mainWrapped(int argc, char * * argv)
         }
         else if (arg == "--print-needed") {
             printNeeded = true;
+        }
+        else if (arg == "--no-sort") {
+            noSort = true;
         }
         else if (arg == "--add-needed") {
             if (++i == argc) error("missing argument");


### PR DESCRIPTION
This PR adds a command line option `--no-sort` which causes patchelf
to refrain from sorting the program headers and section headers.  A
comment in the preexisting source code says that this was done only
"for neatness".

The `--no-sort` option, combined with `readelf -a` and `colordiff` is
very useful for debugging patchelf problems.  Without `--no-sort` the
diffs are not usable -- everything changes because of the sorting.