### PR TITLE
patchelf.cc: handle DT_MIPS_XHASH and .MIPS.xhash

### DIFF
--- a/src/elf.h
+++ b/src/elf.h
@@ -1400,6 +1400,7 @@ typedef struct
 #define SHT_MIPS_EH_REGION	0x70000027
 #define SHT_MIPS_XLATE_OLD	0x70000028
 #define SHT_MIPS_PDR_EXCEPTION	0x70000029
+#define SHT_MIPS_XHASH          0x7000002b
 
 /* Legal values for sh_flags field of Elf32_Shdr.  */
 
@@ -1647,7 +1648,9 @@ typedef struct
    in a PIE as it stores a relative offset from the address of the tag
    rather than an absolute address.  */
 #define DT_MIPS_RLD_MAP_REL  0x70000035
-#define DT_MIPS_NUM          0x36
+/* GNU-style hash table with xlat.  */
+#define DT_MIPS_XHASH        0x70000036
+#define DT_MIPS_NUM          0x37
 
 /* Legal values for DT_MIPS_FLAGS Elf32_Dyn entry.  */
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -990,7 +990,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
                 // some binaries might this section stripped
                 // in which case we just ignore the value.
                 if (shdr) dyn->d_un.d_ptr = (*shdr).get().sh_addr;
-	    } else if (d_tag == DT_MIPS_XHASH) {
+            } else if (d_tag == DT_MIPS_XHASH) {
                 // the .MIPS.xhash section was added to the glibc-ABI
                 // in commit 23c1c256ae7b0f010d0fcaff60682b620887b164
                 dyn->d_un.d_ptr = findSectionHeader(".MIPS.xhash").sh_addr;

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -990,6 +990,10 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
                 // some binaries might this section stripped
                 // in which case we just ignore the value.
                 if (shdr) dyn->d_un.d_ptr = (*shdr).get().sh_addr;
+	    } else if (d_tag == DT_MIPS_XHASH) {
+                // the .MIPS.xhash section was added to the glibc-ABI
+                // in commit 23c1c256ae7b0f010d0fcaff60682b620887b164
+                dyn->d_un.d_ptr = findSectionHeader(".MIPS.xhash").sh_addr;
             } else if (d_tag == DT_JMPREL) {
                 auto shdr = tryFindSectionHeader(".rel.plt");
                 if (!shdr) shdr = tryFindSectionHeader(".rela.plt");


### PR DESCRIPTION
glibc changed their ABI in commit [23c1c256ae7b0f010d0fcaff60682b620887b164](https://sourceware.org/git/?p=glibc.git;a=commit;h=23c1c256ae7b0f010d0fcaff60682b620887b164) on 2019-Aug-29, by changing the structure of the `.gnu.hash` data on MIPS and moving it to a different section.  We need to adapt to this change by glibc.

Closes #368