### PR TITLE
Validate that sections are in bounds

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -266,6 +266,10 @@ ElfFile<ElfFileParamNames>::ElfFile(FileContents fContents)
         Elf_Shdr *shdr = (Elf_Shdr *) (fileContents->data() + rdi(hdr()->e_shoff)) + i;
 
         checkPointer(fileContents, shdr, sizeof(*shdr));
+
+        if (rdi(shdr->sh_offset) + rdi(shdr->sh_size) > fileContents->size())
+            error("section out of bounds");
+
         shdrs.push_back(*shdr);
     }
 


### PR DESCRIPTION
Currently, a section's sh_offset/sh_size fields are not bounds checked. This can
cause a segfault if the .interp/.dynamic sections parsed extend beyond the end
of fie.

This commit adds the missing validation to ElfFile and if found invalid issue an
error message instead.
