### PR TITLE
Handle glibc-hwcaps on ppc64le on CentOS/RHEL/Rocky 8 for tests/replace-add-needed.sh (fixes #406)

### DIFF
--- a/tests/replace-add-needed.sh
+++ b/tests/replace-add-needed.sh
@@ -11,7 +11,7 @@ cp libbar.so ${SCRATCH}/
 
 cd ${SCRATCH}
 
-libcldd=$(ldd ./simple | awk '/ => / { print $3 }' | grep -E "(libc.so|ld-musl)")
+libcldd=$(ldd ./simple | awk '/ => / { print $3 }' | grep -E "(libc(-[0-9.]*)*.so|ld-musl)")
 
 # We have to set the soname on these libraries
 ${PATCHELF} --set-soname libbar.so ./libbar.so


### PR DESCRIPTION
ldd(1) usually returns for ELF binaries output like this:

	libc.so.6 => /lib64/libc.so.6 (0x00007fbacd6ca000)

But with glibc-hwcaps, the output could also be like this:

	libc.so.6 => /lib64/glibc-hwcaps/power9/libc-2.28.so (0x00007fffb5800000)

See also: https://sourceware.org/pipermail/libc-alpha/2020-June/115250.html