### PR TITLE
Fix out of bounds access when increasing program header table

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -689,7 +689,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
     /* Some sections may already be replaced so account for that */
     unsigned int i = 1;
     Elf_Addr pht_size = sizeof(Elf_Ehdr) + (phdrs.size() + num_notes + 1)*sizeof(Elf_Phdr);
-    while( rdi(shdrs.at(i).sh_offset) <= pht_size && i < rdi(hdr()->e_shnum) ) {
+    while( i < rdi(hdr()->e_shnum) && rdi(shdrs.at(i).sh_offset) <= pht_size ) {
         if (not haveReplacedSection(getSectionName(shdrs.at(i))))
             replaceSection(getSectionName(shdrs.at(i)), rdi(shdrs.at(i).sh_size));
         i++;


### PR DESCRIPTION
We check `i < rdi(hdr()->e_shnum)` in the while loop but it was only done so after `shdrs.at(i)` was called, which will crash on out-of-bounds accesses.