### PR TITLE
tests/contiguous-note-sections.sh: use scratch directory

### DIFF
--- a/tests/contiguous-note-sections.sh
+++ b/tests/contiguous-note-sections.sh
@@ -1,6 +1,13 @@
 #! /bin/sh -e
 
+SCRATCH=scratch/$(basename $0 .sh)
+
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
+
+cp contiguous-note-sections "${SCRATCH}/"
+
 # Running --set-interpreter on this binary should not produce the following
 # error:
 # patchelf: cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections
-../src/patchelf --set-interpreter ld-linux-x86-64.so.2 contiguous-note-sections
+../src/patchelf --set-interpreter ld-linux-x86-64.so.2 ${SCRATCH}/contiguous-note-sections


### PR DESCRIPTION
Otherwise, the result of one `make check` invokation will pollute subsequent invokations unless a `make clean` is performed first.