### PR TITLE
Sync .note.gnu.property to PT_GNU_PROPERTY

### DIFF
--- a/src/elf.h
+++ b/src/elf.h
@@ -585,6 +585,7 @@ typedef struct
 #define PT_GNU_EH_FRAME	0x6474e550	/* GCC .eh_frame_hdr segment */
 #define PT_GNU_STACK	0x6474e551	/* Indicates stack executability */
 #define PT_GNU_RELRO	0x6474e552	/* Read-only after relocation */
+#define PT_GNU_PROPERTY	0x6474e553	/* GNU property */
 #define PT_LOSUNW	0x6ffffffa
 #define PT_SUNWBSS	0x6ffffffa	/* Sun Specific segment */
 #define PT_SUNWSTACK	0x6ffffffb	/* Stack segment */

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -652,6 +652,18 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
             }
         }
 
+        /* If there is .note.gnu.property section, then the PT_GNU_PROPERTY
+           segment must be sync'ed with it. */
+        if (sectionName == ".note.gnu.property") {
+            for (auto & phdr : phdrs) {
+                if (rdi(phdr.p_type) == PT_GNU_PROPERTY) {
+                    phdr.p_offset = shdr.sh_offset;
+                    phdr.p_vaddr = phdr.p_paddr = shdr.sh_addr;
+                    phdr.p_filesz = phdr.p_memsz = shdr.sh_size;
+                }
+            }
+        }
+
         curOff += roundUp(i.second.size(), sectionAlignment);
     }
 


### PR DESCRIPTION
PT_GNU_PROPERTY is designed to contain `.note.gnu.property` so we should keep them in sync.