### PR TITLE
Fix Out-of-bounds read in the function modifyRPath

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1371,6 +1371,7 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
        string. */
     std::vector<std::string> neededLibs;
     auto dyn = (Elf_Dyn *)(fileContents->data() + rdi(shdrDynamic.sh_offset));
+    checkPointer(fileContents, dyn, sizeof(*dyn));
     Elf_Dyn *dynRPath = nullptr, *dynRunPath = nullptr;
     char * rpath = nullptr;
     for ( ; rdi(dyn->d_tag) != DT_NULL; dyn++) {


### PR DESCRIPTION
Hi:
Out-of-bounds read exists in the function modifyRPath,  I fixed this issue in this PR 

1. Here's ASAN log:

```
root@iZ2vcadn43p7fjzbhl6zqwZ:~/patchelf_0# /usr/local/bin/patchelf --shrink-rpath sample00900 
AddressSanitizer:DEADLYSIGNAL
=================================================================
==60417==ERROR: AddressSanitizer: SEGV on unknown address 0x626200001e58 (pc 0x557356cd43e7 bp 0x7ffeea76e550 sp 0x7ffeea76dfa0 T0)
==60417==The signal is caused by a READ memory access.
    #0 0x557356cd43e6 in ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, unsigned long, unsigned long, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, unsigned short>::modifyRPath(ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, unsigned long, unsigned long, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, unsigned short>::RPathOp, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /root/patchelf_0/src/patchelf.cc:1376
    #1 0x557356b6ba6c in patchElf2<ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, long unsigned int, long unsigned int, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, short unsigned int> > /root/patchelf_0/src/patchelf.cc:1865
    #2 0x557356b6ba6c in patchElf /root/patchelf_0/src/patchelf.cc:1907
    #3 0x557356b6ba6c in mainWrapped(int, char**) /root/patchelf_0/src/patchelf.cc:2089
    #4 0x557356b56ee5 in main /root/patchelf_0/src/patchelf.cc:2097
    #5 0x7ff86c8b6082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
    #6 0x557356b57bdd in _start (/usr/local/bin/patchelf+0x225bdd)
```

2. Steps to Reproduce
  ./configure --with-asan --with-ubsan
  make & make install
  /usr/local/bin/patchelf --shrink-rpath sample00900

[sample00900.zip](https://github.com/NixOS/patchelf/files/9865746/sample00900.zip)
