### PR TITLE
Fix Out-of-bounds read in the function modifySoname

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1272,6 +1272,7 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
         if (rdi(dyn->d_tag) == DT_SONAME) {
             dynSoname = dyn;
             soname = strTab + rdi(dyn->d_un.d_val);
+            checkPointer(fileContents, strTab, rdi(dyn->d_un.d_val));
         }
     }
 


### PR DESCRIPTION
An OOB Read bug exists in the modifySoname function, I fixed this issue in this PR.

Here is the ASAN log:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==18235==ERROR: AddressSanitizer: SEGV on unknown address 0x7fd0a00230d0 (pc 0x55f8f4610f0d bp 0x7ffe590fe100 sp 0x7ffe590fdd80 T0)
==18235==The signal is caused by a READ memory access.
    #0 0x55f8f4610f0c in ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, unsigned long, unsigned long, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, unsigned short>::modifySoname(ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, unsigned long, unsigned long, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, unsigned short>::sonameMode, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/yairko/Desktop/Research/patchelf/patchelf/src/patchelf.cc:1280
    #1 0x55f8f4495f92 in patchElf2<ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, long unsigned int, long unsigned int, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, short unsigned int> > /home/yairko/Desktop/Research/patchelf/patchelf/src/patchelf.cc:1926
    #2 0x55f8f4495f92 in patchElf /home/yairko/Desktop/Research/patchelf/patchelf/src/patchelf.cc:1980
    #3 0x55f8f4495f92 in mainWrapped(int, char**) /home/yairko/Desktop/Research/patchelf/patchelf/src/patchelf.cc:2162
    #4 0x55f8f4480ee5 in main /home/yairko/Desktop/Research/patchelf/patchelf/src/patchelf.cc:2170
    #5 0x7fd0a37d60b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
    #6 0x55f8f4481bdd in _start (/usr/local/bin/patchelf+0x240bdd)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/yairko/Desktop/Research/patchelf/patchelf/src/patchelf.cc:1280 in ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, unsigned long, unsigned long, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, unsigned short>::modifySoname(ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, unsigned long, unsigned long, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, unsigned short>::sonameMode, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
==18235==ABORTING
```
Steps to reproduce:
./configure --with-asan --with-ubsan
make & make install
/usr/local/bin/patchelf ./oob_bug_poc --print-soname
[poc.zip](https://github.com/NixOS/patchelf/files/10306628/poc.zip)
