### PR TITLE
Add options to print, clear and set executable stack state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Makefile
 /tests/libbig-dynstr.debug
 /tests/contiguous-note-sections
 /tests/simple-pie
+/tests/simple-execstack
 
 .direnv/
 .vscode/

--- a/patchelf.1
+++ b/patchelf.1
@@ -114,6 +114,15 @@ This means that when a shared library has an entry point (so that it
 can be run as an executable), the debugger does not connect to it correctly and
 symbols are not resolved.
 
+.IP "--print-execstack"
+Prints the state of the executable flag of the GNU_STACK program header, if present.
+
+.IP "--clear-execstack"
+Clears the executable flag of the GNU_STACK program header, or adds a new header.
+
+.IP "--set-execstack"
+Sets the executable flag of the GNU_STACK program header, or adds a new header.
+
 .IP "--output FILE"
 Set the output file name.  If not specified, the input will be modified in place.
 

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -105,7 +105,7 @@ private:
 
 public:
 
-    void rewriteSections();
+    void rewriteSections(bool force = false);
 
     std::string getInterpreter();
 
@@ -138,6 +138,10 @@ public:
     void addDebugTag();
 
     void clearSymbolVersions(const std::set<std::string> & syms);
+
+    enum class ExecstackMode { print, set, clear };
+
+    void modifyExecstack(ExecstackMode op);
 
 private:
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 LIBS =
 
-check_PROGRAMS = simple-pie simple main too-many-strtab main-scoped big-dynstr no-rpath contiguous-note-sections
+check_PROGRAMS = simple-pie simple simple-execstack main too-many-strtab main-scoped big-dynstr no-rpath contiguous-note-sections
 
 no_rpath_arch_TESTS = \
   no-rpath-amd64.sh \
@@ -43,7 +43,9 @@ src_TESTS = \
   replace-needed.sh \
   replace-add-needed.sh \
   add-debug-tag.sh \
-  empty-note.sh
+  empty-note.sh \
+  print-execstack.sh \
+  modify-execstack.sh
 
 build_TESTS = \
   $(no_rpath_arch_TESTS)
@@ -71,9 +73,14 @@ export NIX_LDFLAGS=
 simple_SOURCES = simple.c
 # no -fpic for simple.o
 simple_CFLAGS =
+simple_LDFLAGS = -Wl,-z,noexecstack
 
 simple_pie_SOURCES = simple.c
 simple_pie_CFLAGS = -fPIC -pie
+
+simple_execstack_SOURCES = simple.c
+simple_execstack_CFLAGS =
+simple_execstack_LDFLAGS = -Wl,-z,execstack
 
 main_SOURCES = main.c
 main_LDADD = -lfoo $(AM_LDADD)
@@ -108,7 +115,7 @@ check_DATA = libbig-dynstr.debug
 # - without libtool, only archives (static libraries) can be built by automake
 # - with libtool, it is difficult to control options
 # - with libtool, it is not possible to compile convenience *dynamic* libraries :-(
-check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimple.so libbuildid.so libtoomanystrtab.so \
+check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimple.so libsimple-execstack.so libbuildid.so libtoomanystrtab.so \
                   phdr-corruption.so
 
 libbuildid_so_SOURCES = simple.c
@@ -131,7 +138,10 @@ libbar_scoped_so_SOURCES = bar.c
 libbar_scoped_so_LDFLAGS = $(LDFLAGS_sharedlib)
 
 libsimple_so_SOURCES = simple.c
-libsimple_so_LDFLAGS = $(LDFLAGS_sharedlib)
+libsimple_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-z,noexecstack
+
+libsimple_execstack_so_SOURCES = simple.c
+libsimple_execstack_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-z,execstack
 
 too_many_strtab_SOURCES = too-many-strtab.c too-many-strtab2.s
 libtoomanystrtab_so_SOURCES = too-many-strtab.c too-many-strtab2.s

--- a/tests/modify-execstack.sh
+++ b/tests/modify-execstack.sh
@@ -1,0 +1,225 @@
+#! /bin/sh -e
+SCRATCH=scratch/$(basename $0 .sh)
+PATCHELF=$(readlink -f "../src/patchelf")
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+
+cp simple ${SCRATCH}/
+cp simple-execstack ${SCRATCH}/
+cp libsimple.so ${SCRATCH}/
+cp libsimple-execstack.so ${SCRATCH}/
+
+cd ${SCRATCH}
+
+
+## simple
+
+cp simple backup
+
+if ! ${PATCHELF} --print-execstack simple | grep -q 'execstack: -'; then
+	echo "[simple] wrong initial execstack detection"
+	${PATCHELF} --print-execstack simple
+	exit 1
+fi
+
+if ! ${PATCHELF} --clear-execstack simple; then
+	echo "[simple] failed noop initial clear"
+	exit 1
+fi
+
+if ! ${PATCHELF} --set-execstack simple; then
+	echo "[simple] failed set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack simple | grep -q 'execstack: X'; then
+	echo "[simple] wrong execstack detection after set"
+	${PATCHELF} --print-execstack simple
+	exit 1
+fi
+
+if diff simple backup; then
+	echo "[simple] no change after set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --set-execstack simple; then
+	echo "[simple] failed noop set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --clear-execstack simple; then
+	echo "[simple] failed clear after set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack simple | grep -q 'execstack: -'; then
+	echo "[simple] wrong execstack detection after clear after set"
+	${PATCHELF} --print-execstack simple
+	exit 1
+fi
+
+if ! diff simple backup; then
+	echo "[simple] change against backup after clear after set"
+	exit 1
+fi
+
+
+## simple-execstack
+
+cp simple-execstack backup
+
+if ! ${PATCHELF} --print-execstack simple-execstack | grep -q 'execstack: X'; then
+	echo "[simple-execstack] wrong initial execstack detection"
+	${PATCHELF} --print-execstack simple-execstack
+	exit 1
+fi
+
+if ! ${PATCHELF} --set-execstack simple-execstack; then
+	echo "[simple-execstack] failed noop initial set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --clear-execstack simple-execstack; then
+	echo "[simple-execstack] failed clear"
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack simple-execstack | grep -q 'execstack: -'; then
+	echo "[simple-execstack] wrong execstack detection after clear"
+	${PATCHELF} --print-execstack simple-execstack
+	exit 1
+fi
+
+if diff simple-execstack backup; then
+	echo "[simple-execstack] no change after set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --clear-execstack simple-execstack; then
+	echo "[simple-execstack] failed noop clear"
+	exit 1
+fi
+
+if ! ${PATCHELF} --set-execstack simple-execstack; then
+	echo "[simple-execstack] failed set after clear"
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack simple-execstack | grep -q 'execstack: X'; then
+	echo "[simple-execstack] wrong execstack detection after set after clear"
+	${PATCHELF} --print-execstack simple-execstack
+	exit 1
+fi
+
+if ! diff simple-execstack backup; then
+	echo "[simple-execstack] change against backup after set after clear"
+	exit 1
+fi
+
+
+## libsimple.so
+
+cp libsimple.so backup
+
+if ! ${PATCHELF} --print-execstack libsimple.so | grep -q 'execstack: -'; then
+	echo "[libsimple.so] wrong initial execstack detection"
+	${PATCHELF} --print-execstack libsimple.so
+	exit 1
+fi
+
+if ! ${PATCHELF} --clear-execstack libsimple.so; then
+	echo "[libsimple.so] failed noop initial clear"
+	exit 1
+fi
+
+if ! ${PATCHELF} --set-execstack libsimple.so; then
+	echo "[libsimple.so] failed set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack libsimple.so | grep -q 'execstack: X'; then
+	echo "[libsimple.so] wrong execstack detection after set"
+	${PATCHELF} --print-execstack libsimple.so
+	exit 1
+fi
+
+if diff libsimple.so backup; then
+	echo "[libsimple.so] no change after set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --set-execstack libsimple.so; then
+	echo "[libsimple.so] failed noop set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --clear-execstack libsimple.so; then
+	echo "[libsimple.so] failed clear after set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack libsimple.so | grep -q 'execstack: -'; then
+	echo "[libsimple.so] wrong execstack detection after clear after set"
+	${PATCHELF} --print-execstack libsimple.so
+	exit 1
+fi
+
+if ! diff libsimple.so backup; then
+	echo "[libsimple.so] change against backup after clear after set"
+	exit 1
+fi
+
+
+## libsimple-execstack.so
+
+cp libsimple-execstack.so backup
+
+if ! ${PATCHELF} --print-execstack libsimple-execstack.so | grep -q 'execstack: X'; then
+	echo "[libsimple-execstack.so] wrong initial execstack detection"
+	${PATCHELF} --print-execstack libsimple-execstack.so
+	exit 1
+fi
+
+if ! ${PATCHELF} --set-execstack libsimple-execstack.so; then
+	echo "[libsimple-execstack.so] failed noop initial set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --clear-execstack libsimple-execstack.so; then
+	echo "[libsimple-execstack.so] failed clear"
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack libsimple-execstack.so | grep -q 'execstack: -'; then
+	echo "[libsimple-execstack.so] wrong execstack detection after clear"
+	${PATCHELF} --print-execstack libsimple-execstack.so
+	exit 1
+fi
+
+if diff libsimple-execstack.so backup; then
+	echo "[libsimple-execstack.so] no change after set"
+	exit 1
+fi
+
+if ! ${PATCHELF} --clear-execstack libsimple-execstack.so; then
+	echo "[libsimple-execstack.so] failed noop clear"
+	exit 1
+fi
+
+if ! ${PATCHELF} --set-execstack libsimple-execstack.so; then
+	echo "[libsimple-execstack.so] failed set after clear"
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack libsimple-execstack.so | grep -q 'execstack: X'; then
+	echo "[libsimple-execstack.so] wrong execstack detection after set after clear"
+	${PATCHELF} --print-execstack libsimple-execstack.so
+	exit 1
+fi
+
+if ! diff libsimple-execstack.so backup; then
+	echo "[libsimple-execstack.so] change against backup after set after clear"
+	exit 1
+fi

--- a/tests/print-execstack.sh
+++ b/tests/print-execstack.sh
@@ -1,0 +1,23 @@
+#! /bin/sh -e
+SCRATCH=scratch/$(basename $0 .sh)
+PATCHELF=$(readlink -f "../src/patchelf")
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+
+cp simple ${SCRATCH}/
+cp simple-execstack ${SCRATCH}/
+
+cd ${SCRATCH}
+
+if ! ${PATCHELF} --print-execstack simple | grep -q 'execstack: -'; then
+	echo "wrong execstack detection"
+	${PATCHELF} --print-execstack simple
+	exit 1
+fi
+
+if ! ${PATCHELF} --print-execstack simple-execstack | grep -q 'execstack: X'; then
+	echo "wrong execstack detection"
+	${PATCHELF} --print-execstack simple-execstack
+	exit 1
+fi


### PR DESCRIPTION
Add options the modify the state of the executable flag of the GNU_STACK program header. That header indicates whether the object is requiring an executable stack.