### PR TITLE
Avoid overlapping program header table with section header table #457

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -799,7 +799,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
     bool needNewSegment = true;
     auto& lastSeg = phdrs.back();
     /* Try to extend the last segment to include replaced sections */
-    if (phdrs.size() &&
+    if (!phdrs.empty() &&
         rdi(lastSeg.p_type) == PT_LOAD &&
         rdi(lastSeg.p_flags) == (PF_R | PF_W) &&
         rdi(lastSeg.p_align) == getPageSize()) {

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -755,11 +755,16 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
             replaceSection(getSectionName(shdrs.at(i)), rdi(shdrs.at(i).sh_size));
         i++;
     }
+    bool moveHeaderTableToTheEnd = rdi(hdr()->e_shoff) < pht_size;
 
     /* Compute the total space needed for the replaced sections */
     off_t neededSpace = 0;
     for (auto & s : replacedSections)
         neededSpace += roundUp(s.second.size(), sectionAlignment);
+
+    off_t headerTableSpace = roundUp(rdi(hdr()->e_shnum) * rdi(hdr()->e_shentsize), sectionAlignment);
+    if (moveHeaderTableToTheEnd)
+        neededSpace += headerTableSpace;
     debug("needed space is %d\n", neededSpace);
 
     Elf_Off startOffset = roundUp(fileContents->size(), getPageSize());
@@ -789,24 +794,47 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
         startPage = startOffset;
     }
 
-    /* Add a segment that maps the replaced sections into memory. */
     wri(hdr()->e_phoff, sizeof(Elf_Ehdr));
-    phdrs.resize(rdi(hdr()->e_phnum) + 1);
-    wri(hdr()->e_phnum, rdi(hdr()->e_phnum) + 1);
-    Elf_Phdr & phdr = phdrs.at(rdi(hdr()->e_phnum) - 1);
-    wri(phdr.p_type, PT_LOAD);
-    wri(phdr.p_offset, startOffset);
-    wri(phdr.p_vaddr, wri(phdr.p_paddr, startPage));
-    wri(phdr.p_filesz, wri(phdr.p_memsz, neededSpace));
-    wri(phdr.p_flags, PF_R | PF_W);
-    wri(phdr.p_align, getPageSize());
 
+    bool needNewSegment = true;
+    auto& lastSeg = phdrs.back();
+    /* Try to extend the last segment to include replaced sections */
+    if (rdi(lastSeg.p_type) == PT_LOAD &&
+        rdi(lastSeg.p_flags) == (PF_R | PF_W) &&
+        rdi(lastSeg.p_align) == getPageSize()) {
+        auto segEnd = roundUp(rdi(lastSeg.p_offset) + rdi(lastSeg.p_memsz), getPageSize());
+        if (segEnd == startOffset) {
+            auto newSz = startOffset + neededSpace - rdi(lastSeg.p_offset);
+            wri(lastSeg.p_filesz, wri(lastSeg.p_memsz, newSz));
+            needNewSegment = false;
+        }
+    }
+
+    if (needNewSegment) {
+        /* Add a segment that maps the replaced sections into memory. */
+        phdrs.resize(rdi(hdr()->e_phnum) + 1);
+        wri(hdr()->e_phnum, rdi(hdr()->e_phnum) + 1);
+        Elf_Phdr & phdr = phdrs.at(rdi(hdr()->e_phnum) - 1);
+        wri(phdr.p_type, PT_LOAD);
+        wri(phdr.p_offset, startOffset);
+        wri(phdr.p_vaddr, wri(phdr.p_paddr, startPage));
+        wri(phdr.p_filesz, wri(phdr.p_memsz, neededSpace));
+        wri(phdr.p_flags, PF_R | PF_W);
+        wri(phdr.p_align, getPageSize());
+    }
 
     normalizeNoteSegments();
 
 
     /* Write out the replaced sections. */
     Elf_Off curOff = startOffset;
+
+    if (moveHeaderTableToTheEnd) {
+        debug("Moving the shtable to offset %d\n", curOff);
+        wri(hdr()->e_shoff, curOff);
+        curOff += headerTableSpace;
+    }
+
     writeReplacedSections(curOff, startPage, startOffset);
     assert(curOff == startOffset + neededSpace);
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -799,7 +799,8 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
     bool needNewSegment = true;
     auto& lastSeg = phdrs.back();
     /* Try to extend the last segment to include replaced sections */
-    if (rdi(lastSeg.p_type) == PT_LOAD &&
+    if (phdrs.size() &&
+        rdi(lastSeg.p_type) == PT_LOAD &&
         rdi(lastSeg.p_flags) == (PF_R | PF_W) &&
         rdi(lastSeg.p_align) == getPageSize()) {
         auto segEnd = roundUp(rdi(lastSeg.p_offset) + rdi(lastSeg.p_memsz), getPageSize());

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,6 +43,7 @@ src_TESTS = \
   replace-needed.sh \
   replace-add-needed.sh \
   add-debug-tag.sh \
+  repeated-updates.sh \
   empty-note.sh
 
 build_TESTS = \

--- a/tests/repeated-updates.sh
+++ b/tests/repeated-updates.sh
@@ -33,7 +33,7 @@ load_segments_after=$(readelf -W -l libbar.so | grep -c LOAD)
 # To be even more strict, check that we don't add too many extra LOAD entries
 ###############################################################################
 echo "Segments before: ${load_segments_before} and after: ${load_segments_after}"
-if ((${load_segments_after} > ${load_segments_before} + 2 ))
+if [ ${load_segments_after} -gt ${load_segments_before} + 2 ]
 then
     exit 1
 fi

--- a/tests/repeated-updates.sh
+++ b/tests/repeated-updates.sh
@@ -1,0 +1,39 @@
+#! /bin/sh -e
+
+SCRATCH=scratch/$(basename $0 .sh)
+PATCHELF=$(readlink -f "../src/patchelf")
+
+rm -rf ${SCRATCH}
+mkdir -p ${SCRATCH}
+
+cp simple ${SCRATCH}/
+cp libfoo.so ${SCRATCH}/
+cp libbar.so ${SCRATCH}/
+
+cd ${SCRATCH}
+
+${PATCHELF} --add-needed ./libbar.so simple
+
+###############################################################################
+# Test that repeatedly modifying a string inside a shared library does not
+# corrupt it due to the addition of multiple PT_LOAD entries
+###############################################################################
+load_segments_before=$(readelf -W -l libbar.so | grep -c LOAD)
+
+for i in $(seq 1 100)
+do
+    ${PATCHELF} --set-soname ./libbar.so libbar.so
+    ${PATCHELF} --set-soname libbar.so libbar.so
+    ./simple || exit 1
+done
+
+load_segments_after=$(readelf -W -l libbar.so | grep -c LOAD)
+
+###############################################################################
+# To be even more strict, check that we don't add too many extra LOAD entries
+###############################################################################
+echo "Segments before: ${load_segments_before} and after: ${load_segments_after}"
+if ((${load_segments_after} > ${load_segments_before} + 2 ))
+then
+    exit 1
+fi

--- a/tests/repeated-updates.sh
+++ b/tests/repeated-updates.sh
@@ -1,16 +1,16 @@
 #! /bin/sh -e
 
-SCRATCH=scratch/$(basename $0 .sh)
+SCRATCH=scratch/$(basename "$0" .sh)
 PATCHELF=$(readlink -f "../src/patchelf")
 
-rm -rf ${SCRATCH}
-mkdir -p ${SCRATCH}
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
 
-cp simple ${SCRATCH}/
-cp libfoo.so ${SCRATCH}/
-cp libbar.so ${SCRATCH}/
+cp simple "${SCRATCH}/"
+cp libfoo.so "${SCRATCH}/"
+cp libbar.so "${SCRATCH}/"
 
-cd ${SCRATCH}
+cd "${SCRATCH}"
 
 ${PATCHELF} --add-needed ./libbar.so simple
 
@@ -20,7 +20,7 @@ ${PATCHELF} --add-needed ./libbar.so simple
 ###############################################################################
 load_segments_before=$(readelf -W -l libbar.so | grep -c LOAD)
 
-for i in $(seq 1 100)
+for _ in $(seq 1 100)
 do
     ${PATCHELF} --set-soname ./libbar.so libbar.so
     ${PATCHELF} --set-soname libbar.so libbar.so
@@ -33,7 +33,7 @@ load_segments_after=$(readelf -W -l libbar.so | grep -c LOAD)
 # To be even more strict, check that we don't add too many extra LOAD entries
 ###############################################################################
 echo "Segments before: ${load_segments_before} and after: ${load_segments_after}"
-if [ ${load_segments_after} -gt ${load_segments_before} + 2 ]
+if [ "${load_segments_after}" -gt $((load_segments_before + 2)) ]
 then
     exit 1
 fi


### PR DESCRIPTION
This patch does two things to fix the #457 . One could argue they should be separate fixes. They are togethere because they were both needed for the issue in #457 

Please take all changes I make with a grain of salt. I just started learning more about ELF and this codebase, so the solution could be way off.

I observed two issues:
1- Program table overlapping with section table
The tool knows that it might need to insert an extra PT_LOAD for the sections that are relocated to the end of the file. And since growing the program table could overlap with other sections, it checks and marks these overlapping sections as replaced. This makes room for the program table to grow. However, in this case, the the program table will grow into the section table which is right after. This patch detects this scenario and moves the section table to the end (before the replaced sections).

2- Multiple PT_LOAD
Everytime a string is changed (in the issue was through --set-interpreter, but in my test uses --set-soname), the string table needs to be sent to the end of the file to be updated. To do that, the tool adds a new PT_LOAD to the program table. If you repeat this process enough times, this will corrupt the library. So this patch detects that a trailing PT_LOAD already exists and extends it.
After this patch, I was able to patch the elf a thousand times and have a runnable binary.
Unfortunately, I could not understand why adding multiple PT_LOADs eventually corrupt the binary. yet.