### PR TITLE
Modernizations and strictness improvements

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -Wall -std=c++17 -D_FILE_OFFSET_BITS=64
+AM_CXXFLAGS = -Wall -Wcast-qual -std=c++17 -D_FILE_OFFSET_BITS=64
 
 if WITH_ASAN
 AM_CXXFLAGS += -fsanitize=address -fsanitize-address-use-after-scope

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -Wall -Wcast-qual -std=c++17 -D_FILE_OFFSET_BITS=64
+AM_CXXFLAGS = -Wall -Wextra -Wcast-qual -std=c++17 -D_FILE_OFFSET_BITS=64
 
 if WITH_ASAN
 AM_CXXFLAGS += -fsanitize=address -fsanitize-address-use-after-scope

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -236,10 +236,9 @@ struct ElfType
 }
 
 
-static void checkPointer(const FileContents & contents, void * p, unsigned int size)
+static void checkPointer(const FileContents & contents, const void * p, size_t size)
 {
-    auto q = static_cast<unsigned char *>(p);
-    if (!(q >= contents->data() && q + size <= contents->data() + contents->size()))
+    if (p < contents->data() || size > contents->size() || p > contents->data() + contents->size() - size)
         error("data region extends past file end");
 }
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -621,7 +621,7 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
         debug("rewriting section '%s' from offset 0x%x (size %d) to offset 0x%x (size %d)\n",
             sectionName.c_str(), rdi(shdr.sh_offset), rdi(shdr.sh_size), curOff, i->second.size());
 
-        memcpy(fileContents->data() + curOff, (unsigned char *) i->second.c_str(),
+        memcpy(fileContents->data() + curOff, i->second.c_str(),
             i->second.size());
 
         /* Update the section header for this section. */
@@ -1316,7 +1316,7 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
         std::string & newDynamic = replaceSection(".dynamic", rdi(shdrDynamic.sh_size) + sizeof(Elf_Dyn));
 
         unsigned int idx = 0;
-        for (; rdi(((Elf_Dyn *) newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++);
+        for (; rdi(reinterpret_cast<const Elf_Dyn *>(newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++);
         debug("DT_NULL index is %d\n", idx);
 
         /* Shift all entries down by one. */
@@ -1551,7 +1551,7 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
             rdi(shdrDynamic.sh_size) + sizeof(Elf_Dyn));
 
         unsigned int idx = 0;
-        for ( ; rdi(((Elf_Dyn *) newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++) ;
+        for ( ; rdi(reinterpret_cast<const Elf_Dyn *>(newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++) ;
         debug("DT_NULL index is %d\n", idx);
 
         /* Shift all entries down by one. */
@@ -1753,7 +1753,7 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
         rdi(shdrDynamic.sh_size) + sizeof(Elf_Dyn) * libs.size());
 
     unsigned int idx = 0;
-    for ( ; rdi(((Elf_Dyn *) newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++) ;
+    for ( ; rdi(reinterpret_cast<const Elf_Dyn *>(newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++) ;
     debug("DT_NULL index is %d\n", idx);
 
     /* Shift all entries down by the number of new entries. */
@@ -1815,7 +1815,7 @@ void ElfFile<ElfFileParamNames>::noDefaultLib()
                 rdi(shdrDynamic.sh_size) + sizeof(Elf_Dyn));
 
         unsigned int idx = 0;
-        for ( ; rdi(((Elf_Dyn *) newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++) ;
+        for ( ; rdi(reinterpret_cast<const Elf_Dyn *>(newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++) ;
         debug("DT_NULL index is %d\n", idx);
 
         /* Shift all entries down by one. */
@@ -1848,7 +1848,7 @@ void ElfFile<ElfFileParamNames>::addDebugTag()
             rdi(shdrDynamic.sh_size) + sizeof(Elf_Dyn));
 
     unsigned int idx = 0;
-    for ( ; rdi(((Elf_Dyn *) newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++) ;
+    for ( ; rdi(reinterpret_cast<const Elf_Dyn *>(newDynamic.c_str())[idx].d_tag) != DT_NULL; idx++) ;
     debug("DT_NULL index is %d\n", idx);
 
     /* Shift all entries down by one. */

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -2077,7 +2077,7 @@ static void patchElf()
     }
 }
 
-std::string resolveArgument(const char *arg) {
+[[nodiscard]] static std::string resolveArgument(const char *arg) {
   if (strlen(arg) > 0 && arg[0] == '@') {
     FileContents cnts = readFile(arg + 1);
     return std::string((char *)cnts->data(), cnts->size());
@@ -2087,7 +2087,7 @@ std::string resolveArgument(const char *arg) {
 }
 
 
-void showHelp(const std::string & progName)
+static void showHelp(const std::string & progName)
 {
         fprintf(stderr, "syntax: %s\n\
   [--set-interpreter FILENAME]\n\
@@ -2122,7 +2122,7 @@ void showHelp(const std::string & progName)
 }
 
 
-int mainWrapped(int argc, char * * argv)
+static int mainWrapped(int argc, char * * argv)
 {
     if (argc <= 1) {
         showHelp(argv[0]);

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -196,10 +196,10 @@ static FileContents readFile(const std::string & fileName,
     while ((portion = read(fd, contents->data() + bytesRead, size - bytesRead)) > 0)
         bytesRead += portion;
 
+    close(fd);
+
     if (bytesRead != size)
         throw SysError(fmt("reading '", fileName, "'"));
-
-    close(fd);
 
     return contents;
 }

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 #include <optional>
@@ -69,14 +70,18 @@ static int forcedPageSize = -1;
 #define EM_LOONGARCH    258
 #endif
 
-
-static std::vector<std::string> splitColonDelimitedString(const char * s)
+[[nodiscard]] static std::vector<std::string> splitColonDelimitedString(std::string_view s)
 {
-    std::string item;
     std::vector<std::string> parts;
-    std::stringstream ss(s);
-    while (std::getline(ss, item, ':'))
-        parts.push_back(item);
+
+    size_t pos;
+    while ((pos = s.find(':')) != std::string_view::npos) {
+        parts.emplace_back(s.substr(0, pos));
+        s = s.substr(pos + 1);
+    }
+
+    if (!s.empty())
+        parts.emplace_back(s);
 
     return parts;
 }

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -167,7 +167,7 @@ struct SysError : std::runtime_error
     { }
 };
 
-__attribute__((noreturn)) static void error(const std::string & msg)
+[[noreturn]] static void error(const std::string & msg)
 {
     if (errno)
         throw SysError(msg);

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -212,10 +212,10 @@ struct ElfType
 };
 
 
-ElfType getElfType(const FileContents & fileContents)
+[[nodiscard]] static ElfType getElfType(const FileContents & fileContents)
 {
     /* Check the ELF header for basic validity. */
-    if (fileContents->size() < static_cast<off_t>(sizeof(Elf32_Ehdr)))
+    if (fileContents->size() < sizeof(Elf32_Ehdr))
         error("missing ELF header");
 
     auto contents = fileContents->data();

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -535,7 +535,7 @@ std::string ElfFile<ElfFileParamNames>::getSectionName(const Elf_Shdr & shdr) co
 
 
 template<ElfFileParams>
-Elf_Shdr & ElfFile<ElfFileParamNames>::findSectionHeader(const SectionName & sectionName)
+const Elf_Shdr & ElfFile<ElfFileParamNames>::findSectionHeader(const SectionName & sectionName) const
 {
     auto shdr = tryFindSectionHeader(sectionName);
     if (!shdr) {
@@ -549,7 +549,7 @@ Elf_Shdr & ElfFile<ElfFileParamNames>::findSectionHeader(const SectionName & sec
 
 
 template<ElfFileParams>
-std::optional<std::reference_wrapper<Elf_Shdr>> ElfFile<ElfFileParamNames>::tryFindSectionHeader(const SectionName & sectionName)
+std::optional<std::reference_wrapper<const Elf_Shdr>> ElfFile<ElfFileParamNames>::tryFindSectionHeader(const SectionName & sectionName) const
 {
     auto i = getSectionIndex(sectionName);
     if (i)
@@ -602,7 +602,7 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
        clobbering previously written new section contents. */
     for (auto & i : replacedSections) {
         const std::string & sectionName = i.first;
-        Elf_Shdr & shdr = findSectionHeader(sectionName);
+        const Elf_Shdr & shdr = findSectionHeader(sectionName);
         if (rdi(shdr.sh_type) != SHT_NOBITS)
             memset(fileContents->data() + rdi(shdr.sh_offset), 'X', rdi(shdr.sh_size));
     }
@@ -1190,10 +1190,10 @@ static void setSubstr(std::string & s, unsigned int pos, const std::string & t)
 
 
 template<ElfFileParams>
-std::string ElfFile<ElfFileParamNames>::getInterpreter()
+std::string ElfFile<ElfFileParamNames>::getInterpreter() const
 {
     auto shdr = findSectionHeader(".interp");
-    return std::string((char *) fileContents->data() + rdi(shdr.sh_offset), rdi(shdr.sh_size) - 1);
+    return std::string((const char *) fileContents->data() + rdi(shdr.sh_offset), rdi(shdr.sh_size) - 1);
 }
 
 template<ElfFileParams>
@@ -1776,13 +1776,13 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
 }
 
 template<ElfFileParams>
-void ElfFile<ElfFileParamNames>::printNeededLibs() // const
+void ElfFile<ElfFileParamNames>::printNeededLibs() const
 {
     const auto shdrDynamic = findSectionHeader(".dynamic");
     const auto shdrDynStr = findSectionHeader(".dynstr");
-    const char *strTab = (char *)fileContents->data() + rdi(shdrDynStr.sh_offset);
+    const char *strTab = (const char *)fileContents->data() + rdi(shdrDynStr.sh_offset);
 
-    const Elf_Dyn *dyn = (Elf_Dyn *) (fileContents->data() + rdi(shdrDynamic.sh_offset));
+    const Elf_Dyn *dyn = (const Elf_Dyn *) (fileContents->data() + rdi(shdrDynamic.sh_offset));
 
     for (; rdi(dyn->d_tag) != DT_NULL; dyn++) {
         if (rdi(dyn->d_tag) == DT_NEEDED) {

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -290,11 +290,11 @@ ElfFile<ElfFileParamNames>::ElfFile(FileContents fContents)
     /* Get the section header string table section (".shstrtab").  Its
        index in the section header table is given by e_shstrndx field
        of the ELF header. */
-    unsigned int shstrtabIndex = rdi(hdr()->e_shstrndx);
+    auto shstrtabIndex = rdi(hdr()->e_shstrndx);
     if (shstrtabIndex >= shdrs.size())
         error("string table index out of bounds");
 
-    unsigned int shstrtabSize = rdi(shdrs[shstrtabIndex].sh_size);
+    auto shstrtabSize = rdi(shdrs[shstrtabIndex].sh_size);
     char * shstrtab = (char * ) fileContents->data() + rdi(shdrs[shstrtabIndex].sh_offset);
     checkPointer(fileContents, shstrtab, shstrtabSize);
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1472,7 +1472,7 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
         case rpPrint: {
             printf("%s\n", rpath ? rpath : "");
             return;
-        };
+        }
         case rpRemove: {
             if (!rpath) {
                 debug("no RPATH to delete\n");
@@ -1485,7 +1485,7 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
             if (!rpath) {
                 debug("no RPATH to shrink\n");
                 return;
-            ;}
+            }
             newRPath = shrinkRPath(rpath, neededLibs, allowedRpathPrefixes);
             break;
         }

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -104,7 +104,7 @@ static std::string downcase(std::string s)
    why... */
 template<ElfFileParams>
 template<class I>
-I ElfFile<ElfFileParamNames>::rdi(I i) const
+constexpr I ElfFile<ElfFileParamNames>::rdi(I i) const noexcept
 {
     I r = 0;
     if (littleEndian) {
@@ -131,7 +131,7 @@ static void debug(const char * format, ...)
 }
 
 
-void fmt2(std::ostringstream & out)
+static void fmt2([[maybe_unused]] std::ostringstream & out)
 {
 }
 
@@ -309,7 +309,7 @@ ElfFile<ElfFileParamNames>::ElfFile(FileContents fContents)
 
 
 template<ElfFileParams>
-unsigned int ElfFile<ElfFileParamNames>::getPageSize() const
+unsigned int ElfFile<ElfFileParamNames>::getPageSize() const noexcept
 {
     if (forcedPageSize > 0)
         return forcedPageSize;
@@ -555,7 +555,7 @@ std::optional<std::reference_wrapper<Elf_Shdr>> ElfFile<ElfFileParamNames>::tryF
 
 
 template<ElfFileParams>
-unsigned int ElfFile<ElfFileParamNames>::getSectionIndex(const SectionName & sectionName)
+unsigned int ElfFile<ElfFileParamNames>::getSectionIndex(const SectionName & sectionName) const
 {
     for (unsigned int i = 1; i < rdi(hdr()->e_shnum); ++i)
         if (getSectionName(shdrs.at(i)) == sectionName) return i;

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -165,10 +165,10 @@ private:
     }
 
     [[nodiscard]] Elf_Ehdr *hdr() noexcept {
-      return (Elf_Ehdr *)fileContents->data();
+      return reinterpret_cast<Elf_Ehdr *>(fileContents->data());
     }
 
     [[nodiscard]] const Elf_Ehdr *hdr() const noexcept {
-      return (const Elf_Ehdr *)fileContents->data();
+      return reinterpret_cast<const Elf_Ehdr *>(fileContents->data());
     }
 };

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -2,6 +2,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -157,11 +158,14 @@ private:
     constexpr I rdi(I i) const noexcept;
 
     /* Convert back to the ELF representation. */
-    template<class I>
-    constexpr I wri(I & t, unsigned long long i) const
+    template<class I, class U>
+    constexpr inline I wri(I & t, U i) const
     {
-        t = rdi((I) i);
-        return i;
+        I val = static_cast<I>(i);
+        if (static_cast<U>(val) != i)            
+            throw std::runtime_error { "value truncation" };
+        t = rdi(val);
+        return val;
     }
 
     [[nodiscard]] Elf_Ehdr *hdr() noexcept {

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -67,8 +67,6 @@ private:
         }
     };
 
-    friend struct CompPhdr;
-
     void sortPhdrs();
 
     struct CompShdr
@@ -79,8 +77,6 @@ private:
             return elfFile->rdi(x.sh_offset) < elfFile->rdi(y.sh_offset);
         }
     };
-
-    friend struct CompShdr;
 
     [[nodiscard]] unsigned int getPageSize() const noexcept;
 

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -1,3 +1,12 @@
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "elf.h"
+
 using FileContents = std::shared_ptr<std::vector<unsigned char>>;
 
 #define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed, class Elf_Versym

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -87,9 +87,9 @@ private:
 
     [[nodiscard]] std::string getSectionName(const Elf_Shdr & shdr) const;
 
-    Elf_Shdr & findSectionHeader(const SectionName & sectionName);
+    const Elf_Shdr & findSectionHeader(const SectionName & sectionName) const;
 
-    [[nodiscard]] std::optional<std::reference_wrapper<Elf_Shdr>> tryFindSectionHeader(const SectionName & sectionName);
+    [[nodiscard]] std::optional<std::reference_wrapper<const Elf_Shdr>> tryFindSectionHeader(const SectionName & sectionName) const;
 
     [[nodiscard]] unsigned int getSectionIndex(const SectionName & sectionName) const;
 
@@ -113,7 +113,7 @@ public:
 
     void rewriteSections(bool force = false);
 
-    [[nodiscard]] std::string getInterpreter();
+    [[nodiscard]] std::string getInterpreter() const;
 
     typedef enum { printOsAbi, replaceOsAbi } osAbiMode;
 
@@ -137,7 +137,7 @@ public:
 
     void replaceNeeded(const std::map<std::string, std::string> & libs);
 
-    void printNeededLibs() /* should be const */;
+    void printNeededLibs() const;
 
     void noDefaultLib();
 

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -39,14 +39,14 @@ private:
 
     /* Align on 4 or 8 bytes boundaries on 32- or 64-bit platforms
        respectively. */
-    size_t sectionAlignment = sizeof(Elf_Off);
+    static constexpr size_t sectionAlignment = sizeof(Elf_Off);
 
     std::vector<SectionName> sectionsByOldIndex;
 
 public:
     explicit ElfFile(FileContents fileContents);
 
-    bool isChanged()
+    [[nodiscard]] bool isChanged() const noexcept
     {
         return changed;
     }
@@ -55,8 +55,8 @@ private:
 
     struct CompPhdr
     {
-        ElfFile * elfFile;
-        bool operator ()(const Elf_Phdr & x, const Elf_Phdr & y)
+        const ElfFile * elfFile;
+        bool operator ()(const Elf_Phdr & x, const Elf_Phdr & y) const noexcept
         {
             // A PHDR comes before everything else.
             if (elfFile->rdi(y.p_type) == PT_PHDR) return false;
@@ -73,8 +73,8 @@ private:
 
     struct CompShdr
     {
-        ElfFile * elfFile;
-        bool operator ()(const Elf_Shdr & x, const Elf_Shdr & y)
+        const ElfFile * elfFile;
+        bool operator ()(const Elf_Shdr & x, const Elf_Shdr & y) const noexcept
         {
             return elfFile->rdi(x.sh_offset) < elfFile->rdi(y.sh_offset);
         }
@@ -82,24 +82,24 @@ private:
 
     friend struct CompShdr;
 
-    unsigned int getPageSize() const;
+    [[nodiscard]] unsigned int getPageSize() const noexcept;
 
     void sortShdrs();
 
     void shiftFile(unsigned int extraPages, size_t sizeOffset, size_t extraBytes);
 
-    std::string getSectionName(const Elf_Shdr & shdr) const;
+    [[nodiscard]] std::string getSectionName(const Elf_Shdr & shdr) const;
 
     Elf_Shdr & findSectionHeader(const SectionName & sectionName);
 
-    std::optional<std::reference_wrapper<Elf_Shdr>> tryFindSectionHeader(const SectionName & sectionName);
+    [[nodiscard]] std::optional<std::reference_wrapper<Elf_Shdr>> tryFindSectionHeader(const SectionName & sectionName);
 
-    unsigned int getSectionIndex(const SectionName & sectionName);
+    [[nodiscard]] unsigned int getSectionIndex(const SectionName & sectionName) const;
 
     std::string & replaceSection(const SectionName & sectionName,
         unsigned int size);
 
-    bool haveReplacedSection(const SectionName & sectionName) const;
+    [[nodiscard]] bool haveReplacedSection(const SectionName & sectionName) const;
 
     void writeReplacedSections(Elf_Off & curOff,
         Elf_Addr startAddr, Elf_Off startOffset);
@@ -116,7 +116,7 @@ public:
 
     void rewriteSections(bool force = false);
 
-    std::string getInterpreter();
+    [[nodiscard]] std::string getInterpreter();
 
     typedef enum { printOsAbi, replaceOsAbi } osAbiMode;
 
@@ -158,21 +158,21 @@ private:
        specified by the ELF header) to this platform's integer
        representation. */
     template<class I>
-    I rdi(I i) const;
+    constexpr I rdi(I i) const noexcept;
 
     /* Convert back to the ELF representation. */
     template<class I>
-    I wri(I & t, unsigned long long i) const
+    constexpr I wri(I & t, unsigned long long i) const
     {
         t = rdi((I) i);
         return i;
     }
 
-    Elf_Ehdr *hdr() {
+    [[nodiscard]] Elf_Ehdr *hdr() noexcept {
       return (Elf_Ehdr *)fileContents->data();
     }
 
-    const Elf_Ehdr *hdr() const {
+    [[nodiscard]] const Elf_Ehdr *hdr() const noexcept {
       return (const Elf_Ehdr *)fileContents->data();
     }
 };


### PR DESCRIPTION
* modernize the codebase by using modern C++ features
* be more const-correct by using adjusting casts and enable `-Wcast-qual`
* declare more read-only functions `const`
* avoid value truncations in multiple places
* avoid out-of-bounds memory access and integer overflows on malicious ELF data 