### PR TITLE
Adjust roundUp for 0 as input

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -477,6 +477,8 @@ static void writeFile(const std::string & fileName, const FileContents & content
 
 static uint64_t roundUp(uint64_t n, uint64_t m)
 {
+    if (n == 0)
+        return m;
     return ((n - 1) / m + 1) * m;
 }
 


### PR DESCRIPTION
Round up 0 to m instead of wrapping around and return an unexpected result, which is not a multiple of m.
