### PR TITLE
Add define for MIPS_XHASH

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -68,6 +68,10 @@ static int forcedPageSize = DEFAULT_PAGESIZE;
 static int forcedPageSize = -1;
 #endif
 
+#ifndef DT_MIPS_XHASH
+#define DT_MIPS_XHASH   0x70000036
+#endif
+
 #ifndef EM_LOONGARCH
 #define EM_LOONGARCH    258
 #endif


### PR DESCRIPTION
Fixes undeclared identifier error on musl libc (Gentoo amd64/clang), see https://mail-index.netbsd.org/source-changes-hg/2021/05/01/msg290415.html
```bash
clang++ -std=c++17 -DPACKAGE_NAME=\"patchelf\" -DPACKAGE_TARNAME=\"patchelf\" -DPACKAGE_VERSION=\"0.17.2\" -DPACKAGE_STRING=\"patchelf\ 0.17.2\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"patchelf\" -DVERSION=\"0.17.2\" -DHAVE_CXX17=1 -I.    -Wall -std=c++17 -D_FILE_OFFSET_BITS=64     -O3 -pipe -march=skylake -mtune=skylake -D_FORTIFY_SOURCE=3 -stdlib=libc++ -c -o patchelf.o patchelf.cc
patchelf.cc:1087:33: error: use of undeclared identifier 'DT_MIPS_XHASH'
            } else if (d_tag == DT_MIPS_XHASH) {
                                ^
1 error generated.
make[1]: *** [Makefile:380: patchelf.o] Error 1
make[1]: Leaving directory '/var/tmp/portage/dev-util/patchelf-0.17.2/work/patchelf-0.17.2/src'
make: *** [Makefile:448: all-recursive] Error 1
```