### PR TITLE
Other switches might set changed as true. Use extraStrings size. #416

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -2134,7 +2134,7 @@ void ElfFile<ElfFileParamNames>::renameDynamicSymbols(const std::unordered_map<s
         }
     }
 
-    if (changed)
+    if (!extraStrings.empty())
     {
         auto newStrTabSize = strTab.size() + extraStrings.size();
         auto& newSec = replaceSection(".dynstr", newStrTabSize);

--- a/tests/rename-dynamic-symbols.sh
+++ b/tests/rename-dynamic-symbols.sh
@@ -82,3 +82,9 @@ ${PATCHELF} --rename-dynamic-symbols ../map *
 
 echo "# Run the patched tool and libraries"
 env LD_BIND_NOW=1 LD_LIBRARY_PATH=${PWD} ./many-syms-main
+
+# Test that other switches still work when --rename-dynamic-symbols has no effect
+echo "SYMBOL_THAT_DOESNT_EXIST ANOTHER_NAME" > map
+${PATCHELF} --set-rpath changed_rpath --rename-dynamic-symbols map --output libnewrpath.so "$full_lib_name"
+[ "$(${PATCHELF} --print-rpath libnewrpath.so)" = changed_rpath ] || exit 1
+


### PR DESCRIPTION
I didn't realize that "changed" could be set by other switches before reaching the renaming function.
In this case, it tried to add zero strings and failed an assertion due to that.
Added a test that breaks without the fix.