### PR TITLE
Use the largest segment alignment for libraries requiring non-standard alignments #474

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,7 @@ jobs:
           rm -f dist/*
           cd patchelf-*
           ./configure --prefix /patchelf
-          make check
+          make check || (cat tests/test-suite.log; exit 1)
           make install-strip
           cd -
           tar -czf ./dist/patchelf-\$(cat patchelf-*/version)-\$(uname -m).tar.gz -C /patchelf .

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -119,7 +119,7 @@ check_DATA = libbig-dynstr.debug
 # - with libtool, it is difficult to control options
 # - with libtool, it is not possible to compile convenience *dynamic* libraries :-(
 check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimple.so libsimple-execstack.so libbuildid.so libtoomanystrtab.so \
-                  phdr-corruption.so many-syms-main libmany-syms.so
+                  phdr-corruption.so many-syms-main libmany-syms.so liboveralign.so
 
 libbuildid_so_SOURCES = simple.c
 libbuildid_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,--build-id
@@ -142,6 +142,9 @@ libbar_scoped_so_LDFLAGS = $(LDFLAGS_sharedlib)
 
 libsimple_so_SOURCES = simple.c
 libsimple_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-z,noexecstack
+
+liboveralign_so_SOURCES = simple.c
+liboveralign_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-z,max-page-size=0x10000
 
 libsimple_execstack_so_SOURCES = simple.c
 libsimple_execstack_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-z,execstack

--- a/tests/set-rpath-library.sh
+++ b/tests/set-rpath-library.sh
@@ -61,7 +61,7 @@ fi
 # ALL loads should have the same alignment
 lib="${SCRATCH}/liboveralign.so"
 ../src/patchelf --set-rpath "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" "$lib"
-num_alignments=$(${READELF} -W -l "${lib}"  | grep LOAD | awk '{ print $NF }' | sort -u | wc -l)
+num_alignments=$(${READELF} -W -l "${lib}"  | awk '/LOAD/ { print $NF }' | sort -u | wc -l)
 echo "$num_alignments"
 if test "${num_alignments}" -ne "1"; then
     exit 1

--- a/tests/set-rpath-library.sh
+++ b/tests/set-rpath-library.sh
@@ -14,6 +14,7 @@ mkdir -p "${SCRATCH}/libsB"
 cp main-scoped "${SCRATCH}/"
 cp libfoo-scoped.so "${SCRATCH}/libsA/"
 cp libbar-scoped.so "${SCRATCH}/libsB/"
+cp liboveralign.so "${SCRATCH}/"
 
 oldRPath=$(../src/patchelf --print-rpath "${SCRATCH}"/main-scoped)
 if test -z "$oldRPath"; then oldRPath="/oops"; fi
@@ -54,5 +55,14 @@ exitCode=0
 
 if test "$exitCode" != 46; then
     echo "bad exit code!"
+    exit 1
+fi
+
+# ALL loads should have the same alignment
+lib="${SCRATCH}/liboveralign.so"
+../src/patchelf --set-rpath "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" "$lib"
+num_alignments=$(${READELF} -W -l "${lib}"  | grep LOAD | awk '{ print $NF }' | sort -u | wc -l)
+echo "$num_alignments"
+if test "${num_alignments}" -ne "1"; then
     exit 1
 fi


### PR DESCRIPTION
It turns out libraries can have a larger than usual alignment on their LOAD segments. Patchelf should try to play along and use the largest alignment if its going to add a new LOAD segment 