### PR TITLE
Do not let modifyRPath taint shared strings in strtab. Fix #315

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -664,14 +664,14 @@ template<ElfFileParams>
 void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
     Elf_Addr startAddr, Elf_Off startOffset)
 {
-    /* Overwrite the old section contents with 'X's.  Do this
+    /* Overwrite the old section contents with 'Z's.  Do this
        *before* writing the new section contents (below) to prevent
        clobbering previously written new section contents. */
     for (auto & i : replacedSections) {
         const std::string & sectionName = i.first;
         const Elf_Shdr & shdr = findSectionHeader(sectionName);
         if (rdi(shdr.sh_type) != SHT_NOBITS)
-            memset(fileContents->data() + rdi(shdr.sh_offset), 'X', rdi(shdr.sh_size));
+            memset(fileContents->data() + rdi(shdr.sh_offset), 'Z', rdi(shdr.sh_size));
     }
 
     std::set<unsigned int> noted_phdrs = {};

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -10,8 +10,8 @@
 
 using FileContents = std::shared_ptr<std::vector<unsigned char>>;
 
-#define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed, class Elf_Versym, class Elf_Rel, class Elf_Rela, unsigned ElfClass
-#define ElfFileParamNames Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym, Elf_Verneed, Elf_Versym, Elf_Rel, Elf_Rela, ElfClass
+#define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Versym, class Elf_Verdef, class Elf_Verdaux, class Elf_Verneed, class Elf_Vernaux, class Elf_Rel, class Elf_Rela, unsigned ElfClass
+#define ElfFileParamNames Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym, Elf_Versym, Elf_Verdef, Elf_Verdaux, Elf_Verneed, Elf_Vernaux, Elf_Rel, Elf_Rela, ElfClass
 
 template<class T>
 struct span
@@ -234,6 +234,40 @@ private:
             auto newSymIdx = old2newSymId(oldSymIdx);
             if (newSymIdx != oldSymIdx)
                 wri(r.r_info, rel_setSymId(info, newSymIdx));
+        }
+    }
+
+    template<class StrIdxCallback>
+    void forAllStringReferences(const Elf_Shdr& strTabHdr, StrIdxCallback&& fn);
+
+    template<class T, class U>
+    auto follow(U* ptr, size_t offset) -> T* {
+        return offset ? (T*)(((char*)ptr)+offset) : nullptr;
+    };
+
+    template<class VdFn, class VaFn>
+    void forAll_ElfVer(span<Elf_Verdef> vdspan, VdFn&& vdfn, VaFn&& vafn)
+    {
+        auto* vd = vdspan.begin();
+        for (; vd; vd = follow<Elf_Verdef>(vd, rdi(vd->vd_next)))
+        {
+            vdfn(*vd);
+            auto va = follow<Elf_Verdaux>(vd, rdi(vd->vd_aux));
+            for (; va; va = follow<Elf_Verdaux>(va, rdi(va->vda_next)))
+                vafn(*va);
+        }
+    }
+
+    template<class VnFn, class VaFn>
+    void forAll_ElfVer(span<Elf_Verneed> vnspan, VnFn&& vnfn, VaFn&& vafn)
+    {
+        auto* vn = vnspan.begin();
+        for (; vn; vn = follow<Elf_Verneed>(vn, rdi(vn->vn_next)))
+        {
+            vnfn(*vn);
+            auto va = follow<Elf_Vernaux>(vn, rdi(vn->vn_aux));
+            for (; va; va = follow<Elf_Vernaux>(va, rdi(va->vna_next)))
+                vafn(*va);
         }
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,6 +49,7 @@ src_TESTS = \
   modify-execstack.sh \
   rename-dynamic-symbols.sh \
   overlapping-segments-after-rounding.sh \
+  shared-rpath.sh \
   empty-note.sh
 
 build_TESTS = \
@@ -121,7 +122,7 @@ check_DATA = libbig-dynstr.debug
 # - with libtool, it is difficult to control options
 # - with libtool, it is not possible to compile convenience *dynamic* libraries :-(
 check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimple.so libsimple-execstack.so libbuildid.so libtoomanystrtab.so \
-                  phdr-corruption.so many-syms-main libmany-syms.so liboveralign.so
+                  phdr-corruption.so many-syms-main libmany-syms.so liboveralign.so libshared-rpath.so
 
 libbuildid_so_SOURCES = simple.c
 libbuildid_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,--build-id
@@ -147,6 +148,9 @@ libsimple_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-z,noexecstack
 
 liboveralign_so_SOURCES = simple.c
 liboveralign_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-z,max-page-size=0x10000
+
+libshared_rpath_so_SOURCES = shared-rpath.c
+libshared_rpath_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-rpath=a_symbol_name
 
 libsimple_execstack_so_SOURCES = simple.c
 libsimple_execstack_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-z,execstack

--- a/tests/shared-rpath.c
+++ b/tests/shared-rpath.c
@@ -1,0 +1,2 @@
+int a_symbol_name;
+int foo() { return a_symbol_name; }

--- a/tests/shared-rpath.sh
+++ b/tests/shared-rpath.sh
@@ -1,0 +1,51 @@
+#! /bin/sh -e
+
+PATCHELF=$(readlink -f "../src/patchelf")
+SCRATCH="scratch/$(basename "$0" .sh)"
+READELF=${READELF:-readelf}
+
+LIB_NAME="${PWD}/libshared-rpath.so"
+
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
+cd "${SCRATCH}"
+
+has_x() {
+    strings "$1" | grep -c "XXXXXXXX"
+}
+
+nm -D "${LIB_NAME}" | grep a_symbol_name
+previous_cnt="$(strings "${LIB_NAME}" | grep -c a_symbol_name)"
+
+echo "#### Number of a_symbol_name strings in the library: $previous_cnt"
+
+echo "#### Rename the rpath to something larger than the original"
+# Pathelf should detect that the rpath string is shared with the symbol name string and avoid
+# tainting the string with Xs
+"${PATCHELF}" --set-rpath a_very_big_rpath_that_is_larger_than_original  --output liblarge-rpath.so "${LIB_NAME}"
+
+echo "#### Checking symbol is still there"
+nm -D liblarge-rpath.so | grep a_symbol_name
+
+echo "#### Checking there are no Xs"
+[ "$(has_x liblarge-rpath.so)" -eq 0 ] || exit 1
+
+current_cnt="$(strings liblarge-rpath.so | grep -c a_symbol_name)"
+echo "#### Number of a_symbol_name strings in the modified library: $current_cnt"
+[ "$current_cnt" -eq "$previous_cnt" ] || exit 1
+
+echo "#### Rename the rpath to something shorter than the original"
+# Pathelf should detect that the rpath string is shared with the symbol name string and avoid
+# overwriting the existing string
+"${PATCHELF}" --set-rpath shrt_rpth  --output libshort-rpath.so "${LIB_NAME}"
+
+echo "#### Checking symbol is still there"
+nm -D libshort-rpath.so | grep a_symbol_name
+
+echo "#### Number of a_symbol_name strings in the modified library: $current_cnt"
+current_cnt="$(strings libshort-rpath.so | grep -c a_symbol_name)"
+[ "$current_cnt" -eq "$previous_cnt" ] || exit 1
+
+echo "#### Now liblarge-rpath.so should have its own rpath, so it should be allowed to taint it"
+"${PATCHELF}" --set-rpath a_very_big_rpath_that_is_larger_than_original__even_larger  --output liblarge-rpath2.so liblarge-rpath.so
+[ "$(has_x liblarge-rpath2.so)" -eq 1 ] || exit 1


### PR DESCRIPTION
In this PR I add a method to iterate over all fields of the ELF file (as best as we can) that represent indexes in strtable.

I use this method to check if the RPATH string being changed in `modifyRPATH` is shared among multiple fields. If it's shared, don't let patchelf taint the field.

We hope that patchelf continues to taint the vast majority of rpaths (as needed by Nix) but only refrain from doing so when it will break the binary.

Note: The first commit changes the section tainting from X to Z so I can look for the Xs in my tests.