### PR TITLE
Set interpreter only when necessary

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1454,6 +1454,11 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
 template<ElfFileParams>
 void ElfFile<ElfFileParamNames>::setInterpreter(const std::string & newInterpreter)
 {
+    if (getInterpreter() == newInterpreter) {
+        debug("given interpreter is already set\n");
+        return;
+    }
+
     std::string & section = replaceSection(".interp", newInterpreter.size() + 1);
     setSubstr(section, 0, newInterpreter + '\0');
     changed = true;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -51,7 +51,8 @@ src_TESTS = \
   overlapping-segments-after-rounding.sh \
   shared-rpath.sh \
   short-first-segment.sh \
-  empty-note.sh
+  empty-note.sh \
+  set-interpreter-same.sh
 
 build_TESTS = \
   $(no_rpath_arch_TESTS)

--- a/tests/set-interpreter-same.sh
+++ b/tests/set-interpreter-same.sh
@@ -1,0 +1,56 @@
+#! /bin/sh -e
+SCRATCH=scratch/$(basename "$0" .sh)
+
+./simple
+
+curInterpreter=$(../src/patchelf --print-interpreter ./simple)
+echo "current interpreter is $curInterpreter"
+
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
+
+cp simple "${SCRATCH}"/
+
+echo "set the same interpreter as the current one"
+before_checksum=$(sha256sum ${SCRATCH}/simple)
+../src/patchelf --set-interpreter "${curInterpreter}" "${SCRATCH}/simple"
+after_checksum=$(sha256sum ${SCRATCH}/simple)
+
+if [ "$before_checksum" != "$after_checksum" ]; then
+    echo "--set-interpreter should be NOP, but the file has been changed."
+    exit 1
+fi
+
+${SCRATCH}/simple
+
+dummyInterpreter="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+echo "set the dummy interpreter"
+before_checksum=$(sha256sum ${SCRATCH}/simple)
+../src/patchelf --set-interpreter "${dummyInterpreter}" "${SCRATCH}/simple"
+after_checksum=$(sha256sum ${SCRATCH}/simple)
+
+if [ "$before_checksum" = "$after_checksum" ]; then
+    echo "--set-interpreter should be run, but the file has not been changed."
+    exit 1
+fi
+
+if "${SCRATCH}/simple"; then
+    echo "simple works, but it shouldn't"
+    exit 1
+fi
+
+echo "set the same interpreter as the current one"
+before_checksum=$(sha256sum ${SCRATCH}/simple)
+../src/patchelf --set-interpreter "${dummyInterpreter}" "${SCRATCH}/simple"
+after_checksum=$(sha256sum ${SCRATCH}/simple)
+
+if [ "$before_checksum" != "$after_checksum" ]; then
+    echo "--set-interpreter should be NOP, but the file has been changed."
+    exit 1
+fi
+
+if "${SCRATCH}/simple"; then
+    echo "simple works, but it shouldn't"
+    exit 1
+fi


### PR DESCRIPTION
If the value to be written with `--set-intrepreter` has already been set,
the operation can be skipped. Similar checks are already performed by
`modifySoname()` and can be implemented in `setInterpreter()`.

This may avoid the problem that segfaults occur after multiple calls to
`patchelf --set-interpreter` mentioned in the link below.
https://github.com/NixOS/patchelf/issues/492#issuecomment-1610868690

It also prevents the addition of unnecessary LOAD segments each time
`patchelf --set-interpreter` is called.