### PR TITLE
Expand LOAD segment to cover new .dynstr and .dynsym sections

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -787,6 +787,46 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
         curOff += roundUp(i->second.size(), sectionAlignment);
     }
 
+    /* Expand the LOAD segment as neccessary */
+    for (auto & i : replacedSections) {
+        std::string sectionName = i.first;
+
+        /* If this is the .dynstr or .dynsym section, then a PT_LOAD segment
+           must contain it. */
+        if (sectionName == ".dynstr" || sectionName == ".dynsym") {
+            auto const & shdr = findSectionHeader(sectionName);
+            bool loaded = false;
+            for (auto & phdr : phdrs) {
+                if (rdi(phdr.p_type) == PT_LOAD) {
+                    if (rdi(phdr.p_offset) <= rdi(shdr.sh_offset) &&
+                        rdi(shdr.sh_size) <= rdi(phdr.p_filesz)) {
+                        debug("'%s' section is loaded\n", sectionName.c_str());
+                        loaded = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!loaded) {
+                debug("'%s' was moved out of a load segment…\n", sectionName.c_str());
+                for (auto & phdr : phdrs) {
+                    if (rdi(phdr.p_type) == PT_LOAD) {
+                        if (rdi(shdr.sh_offset) < rdi(phdr.p_offset)) {
+                            Elf64_Xword gap = rdi(phdr.p_offset) - rdi(shdr.sh_offset);
+                            debug("grow PT_LOAD segment by 0x%x to cover '%s'\n",
+                                gap, sectionName.c_str());
+                            wri(phdr.p_filesz, rdi(phdr.p_filesz) + gap);
+                            wri(phdr.p_memsz, rdi(phdr.p_memsz) + gap);
+                            phdr.p_vaddr = phdr.p_paddr = shdr.sh_addr;
+                            phdr.p_offset = shdr.sh_offset;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     replacedSections.clear();
 }
 


### PR DESCRIPTION
This is not a robust fix, the first PT_LOAD segment is expanded forward to cover .dynstr or .dynsym.

This is verified to fix segmentation faults in the loader when loading programs where the .dynstr or .dynstm section gets bumped out of the LOAD segment

Fixes: #244

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
