### PR TITLE
Do nothing if interpreter has not changed

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1454,6 +1454,10 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
 template<ElfFileParams>
 void ElfFile<ElfFileParamNames>::setInterpreter(const std::string & newInterpreter)
 {
+    if (getInterpreter() == newInterpreter) {
+        return;
+    }
+
     std::string & section = replaceSection(".interp", newInterpreter.size() + 1);
     setSubstr(section, 0, newInterpreter + '\0');
     changed = true;


### PR DESCRIPTION
If there is not change to the interpreter, don't make any modifications to the file. This is more efficient than requiring programs to check before changing, and also prevents thrashing of the ELF file, since changing the interpreter repeatedly will keep growing the ELF file each time, even if it's the same value.

This is particularly helpful where the same binary is symlinked or hardlinked with multiple names and has patchelf run on it.

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
