### PR TITLE
check all sections if they need a rewrite

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -824,13 +824,11 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
        to overlap the program header table in memory; we need to shift the first
        few segments to someplace else. */
     /* Some sections may already be replaced so account for that */
-    unsigned int i = 1;
     Elf_Addr pht_size = sizeof(Elf_Ehdr) + (phdrs.size() + num_notes + 1)*sizeof(Elf_Phdr);
-    while( i < rdi(hdr()->e_shnum) && rdi(shdrs.at(i).sh_offset) <= pht_size ) {
-        if (not haveReplacedSection(getSectionName(shdrs.at(i))))
-            replaceSection(getSectionName(shdrs.at(i)), rdi(shdrs.at(i).sh_size));
-        i++;
-    }
+    for (unsigned int i = 1; i < rdi(hdr()->e_shnum); ++i)
+        if (rdi(shdrs.at(i).sh_offset) <= pht_size)
+            if (not haveReplacedSection(getSectionName(shdrs.at(i))))
+                replaceSection(getSectionName(shdrs.at(i)), rdi(shdrs.at(i).sh_size));
     bool moveHeaderTableToTheEnd = rdi(hdr()->e_shoff) < pht_size;
 
     /* Compute the total space needed for the replaced sections */


### PR DESCRIPTION
I have a binary with unsorted sections:
```
...
Section Headers:
  [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
  [ 1] .interp           PROGBITS        0000000000000270 000270 00001b 00   A  0   0  1
  [ 2] .note.gnu.build-id NOTE            000000000000028c 00028c 000024 00   A  0   0  4
  [ 3] .note.ABI-tag     NOTE            00000000000002b0 0002b0 000020 00   A  0   0  4
  [ 4] .dynsym           DYNSYM          00000000000020e8 0020e8 001398 18   A  7   1  8
  [ 5] .rela.dyn         RELA            00000000000002d0 0002d0 001398 18   A  4   0  8
...

Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  PHDR           0x000040 0x0000000000000040 0x0000000000000040 0x000230 0x000230 R   0x8
  INTERP         0x000270 0x0000000000000270 0x0000000000000270 0x00001b 0x00001b R   0x1
      [Requesting program interpreter: /lib/ld-linux-aarch64.so.1]
  NOTE           0x00028c 0x000000000000028c 0x000000000000028c 0x000044 0x000044 R   0x4
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x00bb90 0x00bb90 R   0x10000
  LOAD           0x010000 0x0000000000010000 0x0000000000010000 0x00f758 0x00f758 R E 0x10000
  LOAD           0x020000 0x0000000000020000 0x0000000000020000 0x0103c0 0x010870 RW  0x10000
  DYNAMIC        0x0200a8 0x00000000000200a8 0x00000000000200a8 0x0002a0 0x0002a0 RW  0x8
  GNU_EH_FRAME   0x0076bc 0x00000000000076bc 0x00000000000076bc 0x0003ac 0x0003ac R   0x4
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0
  GNU_RELRO      0x020000 0x0000000000020000 0x0000000000020000 0x000a30 0x000a30 R   0x8
...

Relocation section '.rela.dyn' at offset 0x2d0 contains 209 entries:
    Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
0000000000020018  0000000000000403 R_AARCH64_RELATIVE                        13f48
0000000000020020  0000000000000403 R_AARCH64_RELATIVE                        1f6b8
...
```

Running `patchelf` to change the interpreter resulted in rewriting several sections due to additional program headers:
```
Section Headers:
  [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
  [ 1] .rela.dyn         RELA            00000000000002d0 0002d0 001398 18   A  3   0  8
...
  [31] .interp           PROGBITS        0000000000040000 040000 000053 00   A  0   0  8
  [32] .note.ABI-tag     NOTE            0000000000040058 040058 000020 00   A  0   0  4
  [33] .note.gnu.build-id NOTE            0000000000040078 040078 000024 00   A  0   0  4
...

Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  PHDR           0x000040 0x0000000000000040 0x0000000000000040 0x0002a0 0x0002a0 R   0x8
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x00bb90 0x00bb90 R   0x10000
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0
  GNU_EH_FRAME   0x0076bc 0x00000000000076bc 0x00000000000076bc 0x0003ac 0x0003ac R   0x4
  LOAD           0x010000 0x0000000000010000 0x0000000000010000 0x00f758 0x00f758 R E 0x10000
  LOAD           0x020000 0x0000000000020000 0x0000000000020000 0x0103c0 0x010870 RW  0x10000
  GNU_RELRO      0x020000 0x0000000000020000 0x0000000000020000 0x000a30 0x000a30 R   0x8
  DYNAMIC        0x0200a8 0x00000000000200a8 0x00000000000200a8 0x0002a0 0x0002a0 RW  0x8
  INTERP         0x040000 0x0000000000040000 0x0000000000040000 0x000053 0x000053 R   0x1
      [Requesting program interpreter: /nix/store/0ckxcm0bnsh64a4vi40d5wjs96i014nl-glibc-2.37-8/lib/ld-linux-aarch64.so.1]
  LOAD           0x040000 0x0000000000040000 0x0000000000040000 0x0000a0 0x0000a0 RW  0x10000
  NOTE           0x040058 0x0000000000040058 0x0000000000040058 0x000020 0x000020 R   0x4
  NOTE           0x040078 0x0000000000040078 0x0000000000040078 0x000024 0x000024 R   0x4
...

Relocation section '.rela.dyn' at offset 0x2d0 contains 209 entries:
    Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
0000000000000024  0000000000000004 R_AARCH64_P32_PREL16                      13f48
0000000000020020  0000000000000403 R_AARCH64_RELATIVE                        1f6b8
...
```
The modified binary has a corruption of the `.rela.dyn` section. The reason is that the program headers increases in size from 560 bytes (file offsets 64-623) to 672 bytes (file offsets 64-735), which made them overlap with the `.rela.dyn` section (starts at file offset 720). `patchelf` didn't correctly detect that is needs to rewrite the `.rela.dyn` section because it stops scanning the section headers at the first section that doesn't overlap with the longer program headers. This is an error because the section headers are not sorted for the `rewriteSectionsLibrary` function. This PR changes it so that it scans all the sections.