### PR TITLE
tests/short-first-segment: fix uname(1) usage and skip message

### DIFF
--- a/tests/short-first-segment.sh
+++ b/tests/short-first-segment.sh
@@ -11,8 +11,8 @@ if ! gzip --version >/dev/null; then
     exit 77
 fi
 
-if test "$(uname -i)" != x86_64 || test "$(uname)" != Linux; then
-    echo "skipping test: not supported on x86_64 Linux"
+if test "$(uname -m)" != amd64 || test "$(uname)" != Linux; then
+    echo "skipping test: amd64 Linux required"
     exit 77
 fi
 


### PR DESCRIPTION
Replace non-portable GNU `-i, --hardware-platform` with `-m[, --machine]`
to fix "unknown error" usage error on, e.g. OpenBSD.

Also fix the check's backwards logic.  OpenBSD/spar64 now prints
	-skipping test: not supported on x86_64 Linux
	+skipping test: amd64 Linux required
