### PR TITLE
Restrict system operations on OpenBSD

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -2696,6 +2696,11 @@ static int mainWrapped(int argc, char * * argv)
 
 int main(int argc, char * * argv)
 {
+#ifdef __OpenBSD__
+    if (pledge("stdio rpath wpath cpath", NULL) == -1)
+        error("pledge");
+#endif
+
     try {
         return mainWrapped(argc, argv);
     } catch (std::exception & e) {


### PR DESCRIPTION
Use pledge(2)[0] to limit patchelf(1) to read, write and create files.
It never deals with TTY, network, process management or other subsystems.

Do so immediately in main() since mainWrapped() itself parses files
whilst parsing command line arguments (--rename-dynamic-symbols).

This is to reduce patchelf's attack surface and potential damage when
dealing with untrusted ELF programs.

No behaviour change in tests or real world usage observed on
OpenBSD/amd64 7.4 (0.18.0 tests: 56/52/2/2 TOTAL/PASS/FAIL/SKIP).

0: https://man.openbsd.org/pledge.2
