### PR TITLE
Implement `--append-null-phdr` option

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -322,6 +322,8 @@ ElfFile<ElfFileParamNames>::ElfFile(FileContents fContents)
         if (rdi(phdrs[i].p_type) == PT_INTERP) isExecutable = true;
     }
 
+    trailingNullPhdrs = 0;
+
     for (int i = 0; i < rdi(hdr()->e_shnum); ++i) {
         Elf_Shdr *shdr = (Elf_Shdr *) (fileContents->data() + rdi(hdr()->e_shoff)) + i;
 
@@ -1162,13 +1164,24 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
         if (rdi(phdr.p_type) == PT_PHDR) {
             phdr.p_offset = hdr()->e_phoff;
             wri(phdr.p_vaddr, wri(phdr.p_paddr, phdrAddress));
-            wri(phdr.p_filesz, wri(phdr.p_memsz, phdrs.size() * sizeof(Elf_Phdr)));
+            wri(phdr.p_filesz, wri(phdr.p_memsz, (phdrs.size() + trailingNullPhdrs) * sizeof(Elf_Phdr)));
             break;
         }
     }
 
     if (!noSort) {
         sortPhdrs();
+    }
+
+    if (trailingNullPhdrs) {
+        Elf_Phdr nullPhdr = {};
+        nullPhdr.p_type = PT_NULL;
+
+        for (int i = 0; i < trailingNullPhdrs; ++i) {
+            phdrs.push_back(nullPhdr);
+        }
+
+        wri(hdr()->e_phnum, rdi(hdr()->e_phnum) + trailingNullPhdrs);
     }
 
     for (unsigned int i = 0; i < phdrs.size(); ++i)
@@ -1298,7 +1311,13 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
     }
 }
 
-
+template<ElfFileParams>
+void ElfFile<ElfFileParamNames>::appendNullPhdrs(int count)
+{
+  trailingNullPhdrs += count;
+  rewriteHeaders(rdi(hdr()->e_phoff));
+  changed = true;
+}
 
 static void setSubstr(std::string & s, unsigned int pos, const std::string & t)
 {
@@ -2376,6 +2395,7 @@ static bool addDebugTag = false;
 static bool renameDynamicSymbols = false;
 static bool printRPath = false;
 static std::string newRPath;
+static int nullPhdrsToAppend;
 static std::set<std::string> neededLibsToRemove;
 static std::map<std::string, std::string> neededLibsToReplace;
 static std::set<std::string> neededLibsToAdd;
@@ -2444,6 +2464,9 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, con
     if (renameDynamicSymbols)
         elfFile.renameDynamicSymbols(symbolsToRename);
 
+    if (nullPhdrsToAppend)
+        elfFile.appendNullPhdrs(nullPhdrsToAppend);
+
     if (elfFile.isChanged()){
         writeFile(fileName, elfFile.fileContents);
     } else if (alwaysWrite) {
@@ -2496,6 +2519,7 @@ static void showHelp(const std::string & progName)
   [--allowed-rpath-prefixes PREFIXES]\t\tWith '--shrink-rpath', reject rpath entries not starting with the allowed prefix\n\
   [--print-rpath]\n\
   [--force-rpath]\n\
+  [--append-null-phdr]\t\tAppends a PT_NULL program header to the end of the table; may be used multiple times\n\
   [--add-needed LIBRARY]\n\
   [--remove-needed LIBRARY]\n\
   [--replace-needed LIBRARY NEW_LIBRARY]\n\
@@ -2599,6 +2623,9 @@ static int mainWrapped(int argc, char * * argv)
         }
         else if (arg == "--no-sort") {
             noSort = true;
+        }
+        else if (arg == "--append-null-phdr") {
+            ++nullPhdrsToAppend;
         }
         else if (arg == "--add-needed") {
             if (++i == argc) error("missing argument");

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -45,6 +45,8 @@ private:
     std::vector<Elf_Phdr> phdrs;
     std::vector<Elf_Shdr> shdrs;
 
+    int trailingNullPhdrs;
+
     bool littleEndian;
 
     bool changed = false;
@@ -166,6 +168,8 @@ public:
     void noDefaultLib();
 
     void addDebugTag();
+
+    void appendNullPhdrs(int count);
 
     void renameDynamicSymbols(const std::unordered_map<std::string_view, std::string>&);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ src_TESTS = \
   basic-flags.sh \
   set-empty-rpath.sh \
   phdr-corruption.sh \
+  append-null-phdr.sh \
   replace-needed.sh \
   replace-add-needed.sh \
   add-debug-tag.sh \
@@ -123,7 +124,7 @@ check_DATA = libbig-dynstr.debug
 # - with libtool, it is difficult to control options
 # - with libtool, it is not possible to compile convenience *dynamic* libraries :-(
 check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimple.so libsimple-execstack.so libbuildid.so libtoomanystrtab.so \
-                  phdr-corruption.so many-syms-main libmany-syms.so liboveralign.so libshared-rpath.so
+                  phdr-corruption.so append-null-phdr.so many-syms-main libmany-syms.so liboveralign.so libshared-rpath.so
 
 libbuildid_so_SOURCES = simple.c
 libbuildid_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,--build-id
@@ -179,6 +180,10 @@ contiguous_note_sections_CFLAGS = -pie
 phdr_corruption_so_SOURCES = void.c phdr-corruption.ld
 phdr_corruption_so_LDFLAGS = -nostdlib -shared -Wl,-T$(srcdir)/phdr-corruption.ld
 phdr_corruption_so_CFLAGS =
+
+append_null_phdr_so_SOURCES = void.c
+append_null_phdr_so_LDFLAGS = -nostdlib -shared
+append_null_phdr_so_CFLAGS =
 
 many-syms.c:
 	i=1; while [ $$i -le 2000 ]; do echo "void f$$i() {};"; i=$$(($$i + 1)); done > $@

--- a/tests/append-null-phdr.sh
+++ b/tests/append-null-phdr.sh
@@ -1,0 +1,22 @@
+#! /bin/sh -e
+
+PATCHELF="../src/patchelf"
+SONAME="phdr-corruption.so"
+SCRATCH="scratch/$(basename "$0" .sh)"
+SCRATCH_SO="${SCRATCH}/${SONAME}"
+READELF=${READELF:-readelf}
+
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
+cp "${SONAME}" "${SCRATCH}"
+
+"${PATCHELF}" --append-null-phdr --append-null-phdr "${SCRATCH_SO}"
+
+# Check for PT_NULL entries
+readelfData=$(${READELF} -l "${SCRATCH_SO}" 2>&1)
+
+if [ "$(echo "$readelfData" | grep -c "NULL")" != 2 ]; then
+  # Triggered if patchelf doesn't append two PT_NULL entries
+  echo "ERROR: PT_NULL segments were not appended to the program header table!"
+  exit 1
+fi


### PR DESCRIPTION
Appends `PT_NULL` entries to the program header table so that can may be easily targeted by custom tools. Also add automated tests for it.

It works but I can't figure out how to adjust the `PT_LOAD` segments to cover the expanded `PT_PHDR` size. Can you give me some pointers?

Output of `readelf --file-header --program-headers patched`:

```
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              EXEC (Executable file)
  Machine:                           AArch64
  Version:                           0x1
  Entry point address:               0x20284c
  Start of program headers:          64 (bytes into file)
  Start of section headers:          201432 (bytes into file)
  Flags:                             0x0
  Size of this header:               64 (bytes)
  Size of program headers:           56 (bytes)
  Number of program headers:         9
  Size of section headers:           64 (bytes)
  Number of section headers:         16
  Section header string table index: 14

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  PHDR           0x0000000000000040 0x0000000000000040 0x0000000000000040
                 0x00000000000001f8 0x00000000000001f8  R      0x8
readelf: Error: the PHDR segment is not covered by a LOAD segment
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x0
  LOAD           0x0000000000000000 0x0000000000200000 0x0000000000200000
                 0x000000000000184c 0x000000000000184c  R      0x1000
  LOAD           0x000000000000184c 0x000000000020284c 0x000000000020284c
                 0x000000000000b550 0x000000000000b550  R E    0x1000
  LOAD           0x000000000000cda0 0x000000000020eda0 0x000000000020eda0
                 0x00000000000000b8 0x00000000000000b8  RW     0x1000
  GNU_RELRO      0x000000000000cda0 0x000000000020eda0 0x000000000020eda0
                 0x00000000000000b8 0x0000000000000260  R      0x1
  LOAD           0x000000000000ce58 0x000000000020fe58 0x000000000020fe58
                 0x0000000000001358 0x000000000010136d  RW     0x1000
  NULL           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000         0x0
  NULL           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000         0x0

 Section to Segment mapping:
  Segment Sections...
   00
   01
   02     .rodata
   03     .text
   04     .data.rel.ro .got
   05     .data.rel.ro .got
   06     .data .bss
   07
   08
```