### PR TITLE
Fix rename-dynamic-symbols.sh test (issue #503)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -164,7 +164,7 @@ many_syms_main_SOURCES = many-syms-main.c
 many_syms_main_LDFLAGS = $(LDFLAGS_local) 
 many_syms_main_LDADD = -lmany-syms $(AM_LDADD)
 many_syms_main_DEPENDENCIES = libmany-syms.so
-many_syms_main_CFLAGS = -pie
+many_syms_main_CFLAGS = -pie -fPIE
 libmany_syms_so_SOURCES = many-syms.c
 libmany_syms_so_LDFLAGS = $(LDFLAGS_sharedlib)
 


### PR DESCRIPTION
when building and then checking patchelf on openSUSE Leap 15.5, the rename-dynamic-symbols.sh test fails.  The test builds a test library and executable called many-syms-main, then runs patchelf to rename symbols and then checks that many-syms-main still runs successfully.

On Leap the run fails with many messages like

  ./many-syms-main: Symbol `f1947' causes overflow in R_X86_64_PC32 relocation

and then terminates with a Segmentation fault.  The interesting bit is that it however fails so even before patchelf touches it.

The binary is built and linked with option -pie which produces an executable which is supposedly position independent but does not actually contain code position independent code which requires compiler option -fPIE (of -fpie or -fPIC or -fpic).  As a result the calls in the generated assembly do not go through the PLT.

This patch merely adresses that by adding the -fPIE option to the CFLAGS for the test.

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
