### PR TITLE
Fix alignment problem when rewriting sections

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -846,7 +846,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
         neededSpace += headerTableSpace;
     debug("needed space is %d\n", neededSpace);
 
-    Elf_Off startOffset = roundUp(fileContents->size(), getPageSize());
+    Elf_Off startOffset = roundUp(fileContents->size(), alignStartPage);
 
     // In older version of binutils (2.30), readelf would check if the dynamic
     // section segment is strictly smaller than the file (and not same size).
@@ -882,7 +882,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
         rdi(lastSeg.p_type) == PT_LOAD &&
         rdi(lastSeg.p_flags) == (PF_R | PF_W) &&
         rdi(lastSeg.p_align) == alignStartPage) {
-        auto segEnd = roundUp(rdi(lastSeg.p_offset) + rdi(lastSeg.p_memsz), getPageSize());
+        auto segEnd = roundUp(rdi(lastSeg.p_offset) + rdi(lastSeg.p_memsz), alignStartPage);
         if (segEnd == startOffset) {
             auto newSz = startOffset + neededSpace - rdi(lastSeg.p_offset);
             wri(lastSeg.p_filesz, wri(lastSeg.p_memsz, newSz));
@@ -901,6 +901,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
         wri(phdr.p_filesz, wri(phdr.p_memsz, neededSpace));
         wri(phdr.p_flags, PF_R | PF_W);
         wri(phdr.p_align, alignStartPage);
+        assert(startPage % alignStartPage == startOffset % alignStartPage);
     }
 
     normalizeNoteSegments();


### PR DESCRIPTION
After commit ac212d0e6fb8b741e5a5e9ea61091149103f401c the code to
rewrite alignment section has been changed to use the largest alignment
in the list of segments instead of the alignment that it's retrieved
using getPageSize().

Unfortunately the code didn't update the offset as well to keep the
invariant p_vaddr % alignment == p_offset % alignment.

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
