### PR TITLE
Add `--add-rpath-and-shrink` option to do both operations in one go

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,3 @@
-(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+(import (fetchTarball "https://github.com/edolstra/flake-compat/archive/master.tar.gz") {
   src = ./.;
 }).defaultNix

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1477,8 +1477,13 @@ std::string ElfFile<ElfFileParamNames>::shrinkRPath(char* rpath, std::vector<std
     std::vector<bool> neededLibFound(neededLibs.size(), false);
 
     std::string newRPath = "";
+    std::set<std::string> componentsConsidered;
 
     for (auto & dirName : splitColonDelimitedString(rpath)) {
+        if (componentsConsidered.find(dirName) != componentsConsidered.end()) {
+            continue;
+        }
+        componentsConsidered.insert(dirName);
 
         /* Non-absolute entries are allowed (e.g., the special
            "$ORIGIN" hack). */
@@ -1617,6 +1622,14 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
             break;
         }
         case rpSet: { break; } /* new rpath was provied as input to this function */
+        case rpShrinkAndAdd: {
+            auto temp = std::string(rpath ? rpath : "");
+            appendRPath(temp, newRPath);
+            newRPath = temp;
+            char * newRPathCStr = const_cast<char *>(newRPath.c_str());
+            newRPath = shrinkRPath(newRPathCStr, neededLibs, allowedRpathPrefixes);
+            break;
+        }
     }
 
     if (!forceRPath && dynRPath && !dynRunPath) { /* convert DT_RPATH to DT_RUNPATH */
@@ -2419,7 +2432,9 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, con
     else if (setExecstack)
         elfFile.modifyExecstack(ElfFile::ExecstackMode::set);
 
-    if (shrinkRPath)
+    if (shrinkRPath && addRPath)
+        elfFile.modifyRPath(elfFile.rpShrinkAndAdd, allowedRpathPrefixes, newRPath);
+    else if (shrinkRPath)
         elfFile.modifyRPath(elfFile.rpShrink, allowedRpathPrefixes, "");
     else if (removeRPath)
         elfFile.modifyRPath(elfFile.rpRemove, {}, "");
@@ -2566,6 +2581,12 @@ static int mainWrapped(int argc, char * * argv)
         else if (arg == "--allowed-rpath-prefixes") {
             if (++i == argc) error("missing argument");
             allowedRpathPrefixes = splitColonDelimitedString(argv[i]);
+        }
+        else if (arg == "--add-rpath-and-shrink") {
+            if (++i == argc) error("missing argument");
+            addRPath = true;
+            newRPath = resolveArgument(argv[i]);
+            shrinkRPath = true;
         }
         else if (arg == "--set-rpath") {
             if (++i == argc) error("missing argument");

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -149,7 +149,7 @@ public:
 
     void setInterpreter(const std::string & newInterpreter);
 
-    typedef enum { rpPrint, rpShrink, rpSet, rpAdd, rpRemove } RPathOp;
+    typedef enum { rpPrint, rpShrink, rpSet, rpAdd, rpRemove, rpShrinkAndAdd } RPathOp;
 
     void modifyRPath(RPathOp op, const std::vector<std::string> & allowedRpathPrefixes, std::string newRPath);
     std::string shrinkRPath(char* rpath, std::vector<std::string> &neededLibs, const std::vector<std::string> & allowedRpathPrefixes);


### PR DESCRIPTION
__Note:__ I know this is missing an update of the man-page and tests. I'd like to know if you'd be open to accept such a patch in the first place before investing more time into it.

The core issue is that `--shrink-rpath` doesn't free up space filled
with `X` by `--add-rpath`, so using a combination of `--add-rpath` &
`--shrink-rpath` on a virtual env will blow up shared libraries and
cause them to segfault when loaded by Python at some point.

This is not an issue with Nix builds, but it absolutely is when using this
in an imperatively managed virtualenv.

cc @Mic92 

---

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.
