### PR TITLE
Do not build test binaries statically in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,7 @@ jobs:
           path: dist
       - name: Build binaries
         env:
-          CXXFLAGS: "-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wformat -Werror=format-security -O2 -static"
+          CXXFLAGS: "-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wformat -Werror=format-security -O2"
         run: |
           cat <<EOF > build.sh
           set -e
@@ -98,7 +98,7 @@ jobs:
           tar -xf dist/*.tar.bz2
           rm -f dist/*
           cd patchelf-*
-          ./configure --prefix /patchelf
+          ./configure --prefix /patchelf --with-static
           make check || (cat tests/test-suite.log; exit 1)
           make install-strip
           cd -

--- a/configure.ac
+++ b/configure.ac
@@ -41,5 +41,10 @@ AC_ARG_WITH([ubsan],
 )
 AM_CONDITIONAL([WITH_UBSAN], [test x"$with_ubsan" = xyes])
 
+AC_ARG_WITH([static],
+   AS_HELP_STRING([--with-static], [Build static binary])
+)
+AM_CONDITIONAL([WITH_STATIC], [test x"$with_static" = xyes])
+
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile patchelf.spec])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,10 @@ AM_CXXFLAGS += $(SAN_FLAGS)
 endif
 endif
 
+if WITH_STATIC
+AM_CXXFLAGS += -static
+endif
+
 bin_PROGRAMS = patchelf
 
 patchelf_SOURCES = patchelf.cc elf.h patchelf.h

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -82,7 +82,7 @@ export NIX_LDFLAGS=
 simple_SOURCES = simple.c
 # no -fpic for simple.o
 simple_CFLAGS =
-simple_LDFLAGS = -Wl,-z,noexecstack
+simple_LDFLAGS = -Wl,-z,noexecstack -no-pie
 
 simple_pie_SOURCES = simple.c
 simple_pie_CFLAGS = -fPIC -pie
@@ -173,7 +173,7 @@ libmany_syms_so_LDFLAGS = $(LDFLAGS_sharedlib)
 no_rpath_SOURCES = no-rpath.c
 # no -fpic for no-rpath.o
 no_rpath_CFLAGS =
-no_rpath_LDFLAGS =
+no_rpath_LDFLAGS = -no-pie
 
 contiguous_note_sections_SOURCES = contiguous-note-sections.s contiguous-note-sections.ld
 contiguous_note_sections_LDFLAGS = -nostdlib -T $(srcdir)/contiguous-note-sections.ld


### PR DESCRIPTION
For the CI runs intended to be testing static binary, only build the main `patchelf` binary statically, and not the test binaries.  This allows us to restore the correct behavior for toolchain builds with PIE enabled by default.