### PR TITLE
fix: specify zsh completions in patchelf.spec.in

### DIFF
--- a/patchelf.spec.in
+++ b/patchelf.spec.in
@@ -36,3 +36,4 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/patchelf
 %doc %{_docdir}/patchelf/README.md
 %{_mandir}/man1/patchelf.1.gz
+%{_datadir}/zsh/site-functions/_patchelf


### PR DESCRIPTION
Problem: When building the patchelf RPM, zsh completions are installed (but not packaged). This causes an RPM build failure.

Solution: We need to identify the zsh completions in the generated RPM spec file.

Testing: I updated the RPM spec template file and successfully built the RPM.
