### PR TITLE
Drop i686-linux build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   merge_group:
   push:
+    branches:
+      - master
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31
-    - run: nix-build -A hydraJobs.release
+    - run: |
+        nix flake check --extra-experimental-features 'nix-command flakes' --all-systems --no-build
+        nix-build -A hydraJobs.release
   ubuntu:
     runs-on: ubuntu-latest
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,6 @@
 
       supportedSystems = [
         "x86_64-linux"
-        "i686-linux"
         "aarch64-linux"
       ];
       forAllSystems = lib.genAttrs supportedSystems;
@@ -174,14 +173,12 @@
           constituents = [
             self.hydraJobs.tarball
             self.hydraJobs.build.x86_64-linux
-            self.hydraJobs.build.i686-linux
             self.hydraJobs.build-cmake.x86_64-linux
             self.hydraJobs.build-meson.x86_64-linux
             # FIXME: add aarch64 emulation to our github action...
             #self.hydraJobs.build.aarch64-linux
             self.hydraJobs.build-sanitized.x86_64-linux
             #self.hydraJobs.build-sanitized.aarch64-linux
-            self.hydraJobs.build-sanitized.i686-linux
             self.hydraJobs.build-sanitized-clang.x86_64-linux
           ];
           meta.description = "Release-critical builds";
@@ -227,9 +224,6 @@
         {
           glibc = mkShell self.packages.${system}.patchelf;
           default = self.devShells.${system}.glibc;
-        }
-        // lib.optionalAttrs (system != "i686-linux") {
-          musl = mkShell self.packages.${system}.patchelf-musl;
         }
       );
 
@@ -286,9 +280,6 @@
           patchelf-netbsd-cross = patchelfFor pkgs.pkgsCross.x86_64-netbsd;
           patchelf-win32 = patchelfForWindowsStatic pkgs.pkgsCross.mingw32;
           patchelf-win64 = patchelfForWindowsStatic pkgs.pkgsCross.mingwW64;
-        }
-        // lib.optionalAttrs (system != "i686-linux") {
-          patchelf-musl = patchelfFor nixpkgs.legacyPackages.${system}.pkgsMusl;
         }
       );
 


### PR DESCRIPTION
This already failed to evaluate due to pre-commit's dependency on dotnet-sdk, which is unsupported on i686-linux.

It also adds `nix flake check --all-systems --no-build` to CI to catch regressions like this.
