### PR TITLE
readme: document --add-rpath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ libraries.  In particular, it can do the following:
   $ patchelf --set-rpath /opt/my-libs/lib:/other-libs my-program
   ```
 
+* Add a directory to the `RPATH`:
+
+  ```console
+  $ patchelf --add-rpath /opt/my-libs/lib my-program
+  ```
+
+  This appends the specified directory to the existing `RPATH` of the
+  executable or library. Unlike `--set-rpath`, this preserves any
+  existing `RPATH` entries.
+
 * Shrink the `RPATH` of executables and libraries:
 
   ```console


### PR DESCRIPTION
Fixes #586

This PR adds documentation for the `--add-rpath` option to the README.

The `--add-rpath` option was missing from the README, making it difficult for users to discover this feature. This option appends a directory to the existing RPATH, unlike `--set-rpath` which replaces it entirely.

---

This is a documentation-only change, so no regression test is needed.