### PR TITLE
add --force option to write ELF binary without changes

### DIFF
--- a/patchelf.1
+++ b/patchelf.1
@@ -143,6 +143,11 @@ Use sparingly and with caution.
 .IP "--output FILE"
 Set the output file name.  If not specified, the input will be modified in place.
 
+.IP --force
+Force write-out of the ELF binary even when no changes were made.
+This is useful for fixing ELF binaries that have issues like
+"Program headers not in the first page".
+
 .IP --debug
 Prints details of the changes made to the input file.
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -2564,6 +2564,7 @@ static void showHelp(const std::string & progName)
   [--rename-dynamic-symbols NAME_MAP_FILE]\tRenames dynamic symbols. The map file should contain two symbols (old_name new_name) per line\n\
   [--no-clobber-old-sections]\t\tDo not clobber old section values - only use when the binary expects to find section info at the old location.\n\
   [--output FILE]\n\
+  [--force]\t\tForce write-out even if no changes were made\n\
   [--debug]\n\
   [--version]\n\
   FILENAME...\n", progName.c_str());
@@ -2683,6 +2684,9 @@ static int mainWrapped(int argc, char * * argv)
         else if (arg == "--output") {
             if (++i == argc) error("missing argument");
             outputFileName = resolveArgument(argv[i]);
+            alwaysWrite = true;
+        }
+        else if (arg == "--force") {
             alwaysWrite = true;
         }
         else if (arg == "--debug") {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -25,6 +25,7 @@ src_TESTS = \
   set-rpath-library.sh soname.sh shrink-rpath-with-allowed-prefixes.sh \
   set-rpath-rel-map.sh \
   force-rpath.sh \
+  force.sh \
   plain-needed.sh \
   output-flag.sh \
   too-many-strtab.sh \

--- a/tests/force.sh
+++ b/tests/force.sh
@@ -1,0 +1,33 @@
+#! /bin/sh -e
+SCRATCH=scratch/$(basename "$0" .sh)
+
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
+
+cp simple "${SCRATCH}/"
+
+../src/patchelf --force "${SCRATCH}/simple"
+
+exitCode=0
+"${SCRATCH}/simple" || exitCode=$?
+
+if test "$exitCode" != 0; then
+    echo "bad exit code after --force!"
+    exit 1
+fi
+
+cp simple "${SCRATCH}/simple2"
+../src/patchelf --force --output "${SCRATCH}/simple2-out" "${SCRATCH}/simple2"
+
+if ! test -f "${SCRATCH}/simple2-out"; then
+    echo "--force with --output did not create output file!"
+    exit 1
+fi
+
+exitCode=0
+"${SCRATCH}/simple2-out" || exitCode=$?
+
+if test "$exitCode" != 0; then
+    echo "bad exit code after --force --output!"
+    exit 1
+fi


### PR DESCRIPTION
Closes #590

Add `--force` option that forces patchelf to write out the ELF binary even when no modifications were made.

This is useful for fixing ELF binaries that have issues like "Program headers not in the first page" on FreeBSD. Previously, users had to use a workaround like:

```
patchelf --set-interpreter $(patchelf --print-interpreter elf) elf
```

Now they can simply use:

```
patchelf --force elf
```

---

Thank you!

Please do your best to include [a regression test](https://github.com/NixOS/patchelf/blob/master/tests/build-id.sh)
so that the quality of future releases can be preserved.

- [x] Regression test included (`tests/force.sh`)
