### PR TITLE
Fix collision detection for resized PHTs

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -833,7 +833,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
     /* Compute the total space needed for the replaced sections, pessimistically
        assuming we're going to need one more to account for new PT_LOAD covering
        relocated PHDR */
-    off_t phtSize = roundUp((phdrs.size() + num_notes + 1) * sizeof(Elf_Phdr) + sizeof(Elf_Ehdr), sectionAlignment);
+    off_t phtSize = roundUp((phdrs.size() + num_notes + 1) * sizeof(Elf_Phdr), sectionAlignment);
     off_t shtSize = roundUp(rdi(hdr()->e_shnum) * rdi(hdr()->e_shentsize), sectionAlignment);
 
     /* Check if we can keep PHT at the beginning of the file.
@@ -846,31 +846,33 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
          PHDRs not located at the beginning of the file; it was fixed over
          0da1d5002745cdc721bc018b582a8a9704d56c42 (2022-03-02) */
     bool relocatePht = false;
-    unsigned int i = 1;
+    off_t phtEnd = rdi(hdr()->e_phoff) + phtSize;
 
-    while (i < rdi(hdr()->e_shnum) && ((off_t) rdi(shdrs.at(i).sh_offset)) <= phtSize) {
+    for (unsigned int i = 1; i < rdi(hdr()->e_shnum); i++) {
+        off_t shOff = rdi(shdrs.at(i).sh_offset);
+        if (shOff <= (off_t) rdi(hdr()->e_phoff)) continue;
+        if (shOff >= phtEnd) break;
+
         const auto & sectionName = getSectionName(shdrs.at(i));
 
         if (!hasReplacedSection(sectionName) && !canReplaceSection(sectionName)) {
             relocatePht = true;
             break;
         }
-
-        i++;
     }
 
     if (!relocatePht) {
-        unsigned int i = 1;
+        for (unsigned int i = 1; i < rdi(hdr()->e_shnum); i++) {
+            off_t shOff = rdi(shdrs.at(i).sh_offset);
+            if (shOff <= (off_t) rdi(hdr()->e_phoff)) continue;
+            if (shOff >= phtEnd) break;
 
-        while (i < rdi(hdr()->e_shnum) && ((off_t) rdi(shdrs.at(i).sh_offset)) <= phtSize) {
             const auto & sectionName = getSectionName(shdrs.at(i));
             const auto sectionSize = rdi(shdrs.at(i).sh_size);
 
             if (!hasReplacedSection(sectionName)) {
                 replaceSection(sectionName, sectionSize);
             }
-
-            i++;
         }
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,6 +41,7 @@ src_TESTS = \
   basic-flags.sh \
   set-empty-rpath.sh \
   phdr-corruption.sh \
+  pht-collision.sh \
   replace-needed.sh \
   replace-add-needed.sh \
   add-debug-tag.sh \
@@ -125,7 +126,7 @@ check_DATA = libbig-dynstr.debug
 # - with libtool, it is difficult to control options
 # - with libtool, it is not possible to compile convenience *dynamic* libraries :-(
 check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimple.so libsimple-execstack.so libbuildid.so libtoomanystrtab.so \
-                  phdr-corruption.so many-syms-main libmany-syms.so liboveralign.so libshared-rpath.so
+                  phdr-corruption.so pht-collision.so many-syms-main libmany-syms.so liboveralign.so libshared-rpath.so
 
 libbuildid_so_SOURCES = simple.c
 libbuildid_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,--build-id
@@ -182,6 +183,10 @@ contiguous_note_sections_CFLAGS = -pie
 phdr_corruption_so_SOURCES = void.c phdr-corruption.ld
 phdr_corruption_so_LDFLAGS = -nostdlib -shared -Wl,-T$(srcdir)/phdr-corruption.ld
 phdr_corruption_so_CFLAGS =
+
+pht_collision_so_SOURCES = pht-collision.c pht-collision.ld
+pht_collision_so_LDFLAGS = -nostdlib -shared -Wl,-T$(srcdir)/pht-collision.ld
+pht_collision_so_CFLAGS =
 
 many-syms.c:
 	i=1; while [ $$i -le 2000 ]; do echo "void f$$i() {};"; i=$$(($$i + 1)); done > $@

--- a/tests/pht-collision.c
+++ b/tests/pht-collision.c
@@ -1,0 +1,8 @@
+// The PHT will be copied into this buffer after the .so is built
+__attribute__((section(".pht"), used, aligned(16)))
+const char phdr_buf[1024] = {};
+
+// The PHT table will end exactly where this buffer starts.
+__attribute__((section(".adjacent_data"), used, aligned(1)))
+const char buf[16] = {'z', 'z', 'z', 'z', 'z', 'z', 'z', 'z',
+                      'z', 'z', 'z', 'z', 'z', 'z', 'z', 'z'};

--- a/tests/pht-collision.ld
+++ b/tests/pht-collision.ld
@@ -1,0 +1,4 @@
+SECTIONS {
+  .pht : { *(.pht) }
+  .adjacent_data : { *(.adjacent_data) }
+} INSERT BEFORE .dynamic;

--- a/tests/pht-collision.sh
+++ b/tests/pht-collision.sh
@@ -1,0 +1,63 @@
+#! /bin/sh -e
+
+PATCHELF="../src/patchelf"
+SONAME="pht-collision.so"
+SCRATCH="scratch/$(basename "$0" .sh)"
+SCRATCH_SO="${SCRATCH}/${SONAME}"
+READELF=${READELF:-readelf}
+
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
+cp "${SONAME}" "${SCRATCH}"
+
+# Setup: copy the PHT to the end of section .pht, right before .adjacent_data
+adjacent_data_offset=$(${READELF} -WS "${SCRATCH_SO}" | awk -F'[][ ]+' '($3==".adjacent_data"){print $6}')
+adjacent_data_offset=$((0x$adjacent_data_offset))
+
+orig_phoff=$(${READELF} -h "${SCRATCH_SO}" | awk '/Start of program headers:/{print $5}')
+phentsize=$(${READELF} -h "${SCRATCH_SO}" | awk '/Size of program headers:/{print $5}')
+phnum=$(${READELF} -h "${SCRATCH_SO}" | awk '/Number of program headers:/{print $5}')
+pht_size=$((phentsize * phnum))
+
+new_phoff=$((adjacent_data_offset - pht_size))
+dd if="${SCRATCH_SO}" of="${SCRATCH_SO}" bs=1 skip="${orig_phoff}" seek="${new_phoff}" count="${pht_size}" conv=notrunc
+
+# Patch e_phoff in the ELF header to reflect the new location.
+# ELF64: offset 32, 8 bytes (phentsize == 56)
+# ELF32: offset 28, 4 bytes (phentsize == 32)
+if [ "${phentsize}" -eq 56 ]; then
+  phoff_offset=32
+  phoff_size=8
+else
+  phoff_offset=28
+  phoff_size=4
+fi
+# EI_DATA (byte 5): 1 = little-endian, 2 = big-endian
+ei_data=$(dd if="${SCRATCH_SO}" bs=1 skip=5 count=1 2>/dev/null | od -An -tu1 | tr -d ' ')
+offset="${new_phoff}"
+for i in $(seq 0 $((phoff_size - 1))); do
+  if [ "${ei_data}" -eq 2 ]; then
+    byte=$(( (offset >> (8 * (phoff_size - 1 - i))) & 0xff ))
+  else
+    byte=$(( (offset >> (8 * i)) & 0xff ))
+  fi
+  printf "%b" "\\$(printf '%03o' "${byte}")" | dd of="${SCRATCH_SO}" bs=1 seek=$((phoff_offset + i)) count=1 conv=notrunc 2>/dev/null
+done
+
+# Verify PHT was moved correctly
+verify_phoff=$(${READELF} -h "${SCRATCH_SO}" | awk '/Start of program headers:/{print $5}')
+if [ "${verify_phoff}" != "${new_phoff}" ]; then
+  echo "ERROR: Failed to relocate PHT (expected offset ${new_phoff}, got ${verify_phoff})"
+  exit 1
+fi
+
+# Now for the actual test: add a DT_NEEDED and force patchelf to grow the PHT.
+# It should detect that there's no room to grow it in place.
+"${PATCHELF}" --add-needed libfoo.so "${SCRATCH_SO}"
+
+# Verify .adjacent_data still contains 16 'z' characters (0x7a)
+if ! ${READELF} -p .adjacent_data "${SCRATCH_SO}" 2>&1 | grep -q "zzzzzzzzzzzzzzzz"; then
+  echo "ERROR: .adjacent_data was corrupted by PHT expansion!"
+  ${READELF} -x .adjacent_data "${SCRATCH_SO}"
+  exit 1
+fi


### PR DESCRIPTION
Patching a shared library might require extending its program header
table, which can then cause it to run out of its originally allocated
space. After 484d349, patchelf handles this by detecting that growing
the PHT in place would result in a collision with a section that won't
be moved, in which case it instead moves the PHT to the end of the ELF
file.

The logic checking for collisions incorrectly assumes that the PHT is
originally at the start of the file, though. It checks every section
after the first to see if it overlaps with the PHT given its new size,
but it assumes that the PHT's original position is immediately after the
ELF header, `sizeof(Elf_Ehdr)` bytes into the file.

In other words, it's currently looking for collisions in the range:

    [0, roundUp(sizeof(Elf_Ehdr) + newPhtSize, sectionAlignment)]

This commit fixes it to check for collisions in the correct range:

    [hdr()->e_phoff, hdr()->e_phoff + roundUp(newPhtSize, sectionAlignment)]

Closes #643