### PR TITLE
Fix DT_MIPS_RLD_MAP_REL on --remove-rpath

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1599,7 +1599,7 @@ void ElfFile<ElfFileParamNames>::removeRPath(Elf_Shdr & shdrDynamic) {
                *replace* sections we cannot rely on rewriteSections(). So
                we simply fix this one tag in place. */
             if (rdi(dyn->d_tag) == DT_MIPS_RLD_MAP_REL)
-                wri(dyn->d_un.d_val, rdi(dyn->d_un.d_val) + sizeof(Elf_Dyn) * (dyn - last));
+                wri(dyn->d_un.d_ptr, rdi(dyn->d_un.d_ptr) + sizeof(Elf_Dyn) * (dyn - last));
             *last++ = *dyn;
         }
     }

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1593,6 +1593,13 @@ void ElfFile<ElfFileParamNames>::removeRPath(Elf_Shdr & shdrDynamic) {
             debug("removing DT_RUNPATH entry\n");
             changed = true;
         } else {
+            /* the MIPS_RLD_MAP_REL tag stores the offset to the debug
+               pointer, relative to the address of the tag. Therefore we must
+               update the value if the tag is moved down. And since we do not
+               *replace* sections we cannot rely on rewriteSections(). So
+               we simply fix this one tag in place. */
+            if (rdi(dyn->d_tag) == DT_MIPS_RLD_MAP_REL)
+                wri(dyn->d_un.d_val, rdi(dyn->d_un.d_val) + sizeof(Elf_Dyn) * (dyn - last));
             *last++ = *dyn;
         }
     }


### PR DESCRIPTION
## Problem description
removeRpath() uses a simple technique to remove the DT_RPATH/DT_RUNPATH entries from the dynamic section: it removes the elements from the array and moves following tags down.

This works well. Mostly, except when the tag DT_MIPS_RLD_MAP_REL appears. This is a unique tag because its value is a relative offset to the tag's address itself. Thus, when moving the tag down, the offset must be patched as well to componsate for that.

We observed Bus Errors on certain binaries on our MIPS-based products that we could nail down to the introduction of `patchelf --remove-rpath` calls in the build system.

I used AI (Claude Sonnet 4.6) to analyze the problem because I'm not a MIPS expert at all. The patch was written by hand once I understood the root cause. Also I could find "prior art" after the fact in other related software like chrpath and cmake (see [1])

## References
[1] [debian ports](https://groups.google.com/g/linux.debian.ports.mips/c/pyRONW1u1Hg)
