### PR TITLE
Optimize stripping prefix in replaceNeeded

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1815,6 +1815,7 @@ void ElfFile<ElfFileParamNames>::replaceNeeded(const std::map<std::string, std::
             char * name = strTab + rdi(dyn->d_un.d_val);
             auto i = libs.find(name);
             if (i != libs.end() && name != i->second) {
+                auto orig = i->first;
                 auto replacement = i->second;
 
                 debug("replacing DT_NEEDED entry '%s' with '%s'\n", name, replacement.c_str());
@@ -1822,7 +1823,21 @@ void ElfFile<ElfFileParamNames>::replaceNeeded(const std::map<std::string, std::
                 auto a = addedStrings.find(replacement);
                 // the same replacement string has already been added, reuse it
                 if (a != addedStrings.end()) {
+                    debug("reusing previous replacement\n");
                     wri(dyn->d_un.d_val, a->second);
+                    continue;
+                }
+
+                // if the replacement a suffix of the original, e.g. when replacing full
+                // paths with the basename or stripping a sysroot-like prefix, then
+                // update the reference to that suffix while keeping the original
+                // intact (thus we can potentially avoid relocating the whole section)
+                auto pos = orig.rfind(replacement);
+                if (pos != std::string::npos && orig.size() == pos + replacement.size()) {
+                    debug("reusing suffix\n");
+                    wri(dyn->d_un.d_val, rdi(dyn->d_un.d_val) + pos);
+                    /* ensure write-out in case all replaces use this technique */
+                    changed = true;
                     continue;
                 }
 


### PR DESCRIPTION
This superseeds #635 (now from my company github account)

We can avoid resizing .dynstr if the user just requested to strip a prefix. More importanly, we can avoid relocating the section to the end of the binary which is almost always mandatory since .dynstr only ever grows.

This is a common use case when replacing fully-qualified needed entries (e.g. absolute build paths) with just its base name (to have the runtime linker do the search).

I originally made this patch to side-step a problem on MIPS that occurs during rewriting sections when using `--replace-needed` as described above. However, this appears to be fixed by #642 , which is great since I never fully understood the root cause.

But I think the change is worthwhile nevertheless because it avoids a truly invasive operation on the binary when not really needed.

Thank you!