### PR TITLE
tests: add property test for binary-preserving rewrites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: cachix/install-nix-action@v31
+    - uses: Mic92/hestia@v1
     - run: nix-build -A hydraJobs.release
   ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/hestia-gc.yml
+++ b/.github/workflows/hestia-gc.yml
@@ -1,0 +1,31 @@
+name: Hestia cache GC
+
+# PR-scoped caches die with their branch; the default-branch scope grows
+# forever without this.
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Plan only; delete nothing.
+        type: boolean
+        default: false
+
+# Two GCs racing corrupts the repack; queue, don't overlap.
+concurrency:
+  group: hestia-gc
+  cancel-in-progress: false
+
+jobs:
+  gc:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write   # REST cache deletes
+      contents: read
+    steps:
+      - uses: Mic92/hestia@v1
+      - run: |
+          "$HESTIA_BIN" gc ${{ inputs.dry-run && '--dry-run' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,6 +126,40 @@ jobs:
           name: patchelf-${{ matrix.platform }}
           path: dist/*
 
+  # Architectures without an official musl/Alpine image: build with glibc on
+  # Debian under QEMU and just run the test suite (no release artifact).
+  test_qemu_glibc:
+    name: Test under QEMU (glibc)
+    needs: [build_tarballs]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ["mips64le"]
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - uses: actions/download-artifact@v6
+        with:
+          name: patchelf-tarball
+          path: dist
+      - name: Build and test
+        run: |
+          cat <<'EOF' > check.sh
+          set -ex
+          apt-get update
+          apt-get install -y --no-install-recommends build-essential file
+          tar -xf dist/*.tar.bz2
+          cd patchelf-*
+          ./configure
+          # qemu emulation is slow, so keep the randomized property test short.
+          export ITERS=10
+          make check || (cat tests/test-suite.log; exit 1)
+          EOF
+          # bookworm still carries mips64el in the main archive; unstable does not.
+          docker run --platform "linux/${{ matrix.platform }}" -v "$(pwd):/gha" \
+            "${{ matrix.platform }}/debian:bookworm-slim" sh -ec "cd /gha && sh ./check.sh"
+
   publish:
     name: Publish tarballs & binaries
     needs: [build_tarballs, build_windows, build_musl]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - uses: cachix/install-nix-action@v31
+      - uses: Mic92/hestia@v1
       - name: Build tarballs
         run: |
           nix build -L .#hydraJobs.tarball
@@ -33,6 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - uses: cachix/install-nix-action@v31
+      - uses: Mic92/hestia@v1
       - name: Build windows executable
         run: |
           nix build -L .#patchelf-win32 .#patchelf-win64

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ CMakeLists.txt.user
 .vscode/
 .idea/
 result
+/tests/property-fail-*

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ CMakeLists.txt.user
 /tests/contiguous-note-sections
 /tests/simple-pie
 /tests/simple-execstack
+/tests/large-page
 
 .direnv/
 .vscode/

--- a/flake.nix
+++ b/flake.nix
@@ -218,6 +218,8 @@
                   #pkgs.buildPackages.cmake
                   #pkgs.buildPackages.meson
                   #pkgs.buildPackages.ninja
+                  pkgs.buildPackages.lld
+                  pkgs.buildPackages.mold
                   modular.pre-commit.settings.package
                   (pkgs.buildPackages.writeScriptBin "pre-commit-hooks-install" modular.pre-commit.settings.installationScript)
                 ];

--- a/package-autotools.nix
+++ b/package-autotools.nix
@@ -1,6 +1,8 @@
 {
   stdenv,
   autoreconfHook,
+  lld,
+  mold,
   version,
   src,
 }:
@@ -9,5 +11,11 @@ stdenv.mkDerivation {
   pname = "patchelf";
   inherit version src;
   nativeBuildInputs = [ autoreconfHook ];
+  # Extra linkers so tests/property-rewrite.sh can exercise the layouts they
+  # produce; the test degrades gracefully when a linker is missing.
+  nativeCheckInputs = [
+    lld
+    mold
+  ];
   doCheck = true;
 }

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1095,16 +1095,44 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsExecutable()
 
     debug("needed space is %d\n", neededSpace);
 
+    /* A writable section (commonly .dynamic, which the loader writes DT_DEBUG
+       into) may be relocated into the reserved area, so the segment covering
+       that area must end up writable. */
+    bool needWritable = std::any_of(replacedSections.begin(), replacedSections.end(),
+        [this](const std::pair<const std::string, std::string> & i) {
+            return (rdi(findSectionHeader(i.first).sh_flags) & SHF_WRITE) != 0;
+        });
+
+    /* If that area sits in an executable LOAD segment, marking it writable
+       would create a W+X segment. Prefer to grow the file instead, so shiftFile
+       splits the reserved area into its own R/W segment and leaves the
+       executable one untouched. Growing adds one program header and one page;
+       only take this path when both fit (otherwise the underrun check below
+       would abort), else fall back to marking the segment writable (W+X). */
+    bool growForWritable = false;
+    if (needWritable && neededSpace + sizeof(Elf_Phdr) <= startOffset
+        && firstPage >= getPageSize()) {
+        Elf_Off hdrOff = sizeof(Elf_Ehdr) + phdrs.size() * sizeof(Elf_Phdr);
+        for (const auto & phdr : phdrs)
+            if (rdi(phdr.p_type) == PT_LOAD &&
+                rdi(phdr.p_offset) <= hdrOff &&
+                rdi(phdr.p_offset) + rdi(phdr.p_filesz) > hdrOff)
+            {
+                growForWritable = (rdi(phdr.p_flags) & PF_X) != 0;
+                break;
+            }
+    }
+
     /* If we need more space at the start of the file, then grow the
        file by the minimum number of pages and adjust internal
        offsets. */
-    if (neededSpace > startOffset) {
+    if (neededSpace > startOffset || growForWritable) {
         /* We also need an additional program header, so adjust for that. */
         neededSpace += sizeof(Elf_Phdr);
         debug("needed space is %d\n", neededSpace);
 
         /* Calculate how many bytes are needed out of the additional pages. */
-        size_t extraSpace = neededSpace - startOffset;
+        size_t extraSpace = neededSpace > startOffset ? neededSpace - startOffset : 0;
         // Always give one extra page to avoid colliding with segments that start at
         // unaligned addresses and will be rounded down when loaded
         unsigned int neededPages = 1 + roundUp(extraSpace, getPageSize()) / getPageSize();
@@ -1128,11 +1156,20 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsExecutable()
     for (auto& phdr : phdrs)
         if (rdi(phdr.p_type) == PT_LOAD &&
             rdi(phdr.p_offset) <= curOff &&
-            rdi(phdr.p_offset) + rdi(phdr.p_filesz) > curOff &&
-            rdi(phdr.p_filesz) < neededSpace)
+            rdi(phdr.p_offset) + rdi(phdr.p_filesz) > curOff)
         {
-            wri(phdr.p_filesz, neededSpace);
-            wri(phdr.p_memsz, neededSpace);
+            if (rdi(phdr.p_filesz) < neededSpace) {
+                wri(phdr.p_filesz, neededSpace);
+                wri(phdr.p_memsz, neededSpace);
+            }
+            /* The segment may already be large enough (e.g. with a large page
+               size), so set this regardless of whether it was extended. If a
+               grow happened above this is the new R/W segment shiftFile created
+               and the flag is already set; otherwise we set it here, which for
+               an executable segment is the W+X fallback when growing was not
+               possible. */
+            if (needWritable)
+                wri(phdr.p_flags, rdi(phdr.p_flags) | PF_W);
             break;
         }
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -1657,30 +1657,38 @@ std::string ElfFile<ElfFileParamNames>::shrinkRPath(char* rpath, std::vector<std
     return newRPath;
 }
 
+/* Remove every entry matched by drop() from .dynamic in place, shifting later
+   entries down and zeroing the tail. DT_MIPS_RLD_MAP_REL is relative to its
+   own slot's address, so a kept entry that moved gets its value adjusted by
+   the distance shifted; rewriteHeaders() would recompute it from the section
+   address, but that only runs when .dynamic is replaced, and this compacts in
+   place. Returns whether anything was dropped. */
+template<ElfFileParams>
+template<class Drop>
+bool ElfFile<ElfFileParamNames>::compactDynamic(Elf_Shdr & shdrDynamic, Drop && drop)
+{
+    auto dynSpan = getSectionSpan<Elf_Dyn>(shdrDynamic);
+    Elf_Dyn * out = dynSpan.begin();
+    Elf_Dyn * dyn = out;
+    for ( ; dyn < dynSpan.end() && rdi(dyn->d_tag) != DT_NULL; dyn++) {
+        if (drop(*dyn)) continue;
+        *out = *dyn;
+        if (out != dyn && rdi(out->d_tag) == DT_MIPS_RLD_MAP_REL)
+            wri(out->d_un.d_ptr, rdi(out->d_un.d_ptr) + (dyn - out) * sizeof(Elf_Dyn));
+        out++;
+    }
+    memset(out, 0, sizeof(Elf_Dyn) * (dyn - out));
+    return out != dyn;
+}
+
 template<ElfFileParams>
 void ElfFile<ElfFileParamNames>::removeRPath(Elf_Shdr & shdrDynamic) {
-    auto dynSpan = getSectionSpan<Elf_Dyn>(shdrDynamic);
-    Elf_Dyn * dyn = dynSpan.begin();
-    Elf_Dyn * last = dyn;
-    for ( ; dyn < dynSpan.end() && rdi(dyn->d_tag) != DT_NULL; dyn++) {
-        if (rdi(dyn->d_tag) == DT_RPATH) {
-            debug("removing DT_RPATH entry\n");
-            changed = true;
-        } else if (rdi(dyn->d_tag) == DT_RUNPATH) {
-            debug("removing DT_RUNPATH entry\n");
-            changed = true;
-        } else {
-            /* the MIPS_RLD_MAP_REL tag stores the offset to the debug
-               pointer, relative to the address of the tag. Therefore we must
-               update the value if the tag is moved down. And since we do not
-               *replace* sections we cannot rely on rewriteSections(). So
-               we simply fix this one tag in place. */
-            if (rdi(dyn->d_tag) == DT_MIPS_RLD_MAP_REL)
-                wri(dyn->d_un.d_ptr, rdi(dyn->d_un.d_ptr) + sizeof(Elf_Dyn) * (dyn - last));
-            *last++ = *dyn;
-        }
-    }
-    memset(last, 0, sizeof(Elf_Dyn) * (dyn - last));
+    changed |= compactDynamic(shdrDynamic, [this](const Elf_Dyn & d) {
+        auto tag = rdi(d.d_tag);
+        if (tag != DT_RPATH && tag != DT_RUNPATH) return false;
+        debug("removing %s entry\n", tag == DT_RPATH ? "DT_RPATH" : "DT_RUNPATH");
+        return true;
+    });
     this->rewriteSections();
 }
 
@@ -1858,28 +1866,19 @@ void ElfFile<ElfFileParamNames>::removeNeeded(const std::set<std::string> & libs
     auto shdrDynStr = findSectionHeader(".dynstr");
     auto strTab = getStrTab(shdrDynStr);
 
-    auto dynSpan = getSectionSpan<Elf_Dyn>(shdrDynamic);
-    Elf_Dyn * dyn = dynSpan.begin();
-    Elf_Dyn * last = dyn;
-    bool removed = false;
-    for ( ; dyn < dynSpan.end() && rdi(dyn->d_tag) != DT_NULL; dyn++) {
-        if (rdi(dyn->d_tag) == DT_NEEDED) {
-            char * name = strTabEntry(strTab, rdi(dyn->d_un.d_val));
-            if (libs.count(name)) {
-                debug("removing DT_NEEDED entry '%s'\n", name);
-                changed = true;
-                removed = true;
-            } else {
-                debug("keeping DT_NEEDED entry '%s'\n", name);
-                *last++ = *dyn;
-            }
-        } else
-            *last++ = *dyn;
+    if (compactDynamic(shdrDynamic, [&](const Elf_Dyn & d) {
+        if (rdi(d.d_tag) != DT_NEEDED) return false;
+        char * name = strTabEntry(strTab, rdi(d.d_un.d_val));
+        if (!libs.count(name)) {
+            debug("keeping DT_NEEDED entry '%s'\n", name);
+            return false;
+        }
+        debug("removing DT_NEEDED entry '%s'\n", name);
+        return true;
+    })) {
+        changed = true;
+        removeResolutionCache();
     }
-
-    memset(last, 0, sizeof(Elf_Dyn) * (dyn - last));
-
-    if (removed) removeResolutionCache();
 
     this->rewriteSections();
 }

--- a/src/patchelf.h
+++ b/src/patchelf.h
@@ -159,6 +159,9 @@ public:
     std::string shrinkRPath(char* rpath, std::vector<std::string> &neededLibs, const std::vector<std::string> & allowedRpathPrefixes);
     void removeRPath(Elf_Shdr & shdrDynamic);
 
+    template<class Drop>
+    bool compactDynamic(Elf_Shdr & shdrDynamic, Drop && drop);
+
     unsigned int dynNullIndex(const std::string & newDynamic) const;
 
     void addNeeded(const std::set<std::string> & libs);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,7 @@ src_TESTS = \
   set-interpreter-long.sh set-rpath.sh add-rpath.sh no-rpath.sh big-dynstr.sh \
   set-rpath-library.sh soname.sh shrink-rpath-with-allowed-prefixes.sh \
   set-rpath-rel-map.sh \
+  remove-rld-map-rel.sh \
   force-rpath.sh \
   plain-needed.sh \
   output-flag.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ src_TESTS = \
   short-first-segment.sh \
   empty-note.sh \
   set-interpreter-same.sh \
+  property-rewrite.sh \
   large-page-dynamic.sh
 
 build_TESTS = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 LIBS =
 
-check_PROGRAMS = simple-pie simple simple-execstack main main-no-pie main-emit-relocs pad-to-page too-many-strtab main-scoped big-dynstr no-rpath contiguous-note-sections
+check_PROGRAMS = simple-pie simple simple-execstack main main-no-pie main-emit-relocs pad-to-page too-many-strtab main-scoped big-dynstr no-rpath contiguous-note-sections large-page
 
 no_rpath_arch_TESTS = \
   no-rpath-alpha.sh \
@@ -60,7 +60,8 @@ src_TESTS = \
   shared-rpath.sh \
   short-first-segment.sh \
   empty-note.sh \
-  set-interpreter-same.sh
+  set-interpreter-same.sh \
+  large-page-dynamic.sh
 
 build_TESTS = \
   $(no_rpath_arch_TESTS)
@@ -109,6 +110,13 @@ main_no_pie_CFLAGS = -fno-pie
 main_no_pie_LDADD = -lfoo $(AM_LDADD)
 main_no_pie_DEPENDENCIES = libfoo.so
 main_no_pie_LDFLAGS = $(LDFLAGS_local) -no-pie
+
+# Non-PIE binary with a max-page-size larger than the runtime page size. On
+# 32-bit targets this makes patchelf relocate .dynamic into the read-only first
+# segment; see large-page-dynamic.sh.
+large_page_SOURCES = simple.c
+large_page_CFLAGS = -fno-pie
+large_page_LDFLAGS = $(LDFLAGS_local) -no-pie -Wl,-z,max-page-size=0x200000
 
 # Variant of main that retains named SECTION symbols in .symtab (via
 # --emit-relocs), so the symbol-table rewrite can be checked for corruption.

--- a/tests/large-page-dynamic.sh
+++ b/tests/large-page-dynamic.sh
@@ -1,0 +1,28 @@
+#! /bin/sh -e
+# Non-PIE executable linked with a max-page-size larger than the runtime page.
+# On 32-bit targets patchelf used to relocate .dynamic into the read-only first
+# LOAD segment, so the loader segfaulted writing DT_DEBUG. The bug does not
+# reproduce on 64-bit, so the check is scoped to ELF32.
+SCRATCH=scratch/$(basename "$0" .sh)
+READELF=${READELF:-readelf}
+
+skip() { echo "SKIP: $1"; exit 77; }
+hdr=$(${READELF} -h large-page)
+case $hdr in *Class:*ELF32*) ;; *) skip "not a 32-bit binary" ;; esac
+case $hdr in *Type:*EXEC*)  ;; *) skip "toolchain did not produce ET_EXEC" ;; esac
+# 32-bit ARM's default image base is 0x10000, so the 2 MiB page alignment makes
+# the linker emit a LOAD at vaddr 0. Under qemu-user that hits the host's
+# mmap_min_addr and the unpatched binary already cannot run, so the test is not
+# meaningful there. (i386's 0x08048000 base leaves room and exercises the fix.)
+case $hdr in *'Machine:'*' ARM'*) skip "ARM image base is below max-page-size" ;; esac
+
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
+cp large-page "${SCRATCH}/app"
+cp libfoo.so libbar.so "${SCRATCH}/"
+
+# --add-needed grows .dynamic, forcing patchelf to relocate it. The binary must
+# still run: the loader writes DT_DEBUG into .dynamic, which segfaults if it
+# landed in a read-only segment.
+../src/patchelf --add-needed libfoo.so "${SCRATCH}/app"
+LD_LIBRARY_PATH="${SCRATCH}" "${SCRATCH}/app"

--- a/tests/property-rewrite.sh
+++ b/tests/property-rewrite.sh
@@ -1,0 +1,194 @@
+#!/bin/sh -e
+# Property: applying patchelf to a valid, runnable binary keeps it runnable.
+#
+# Each case builds a dynamic executable with randomized layout/link options.
+# It then applies a random sequence of patchelf operations.
+# The binary is run after each one.
+# A case that fails to build or run before patching is skipped, not failed.
+#
+# Point PATCHELF at a sanitizer build for deeper checks, e.g.
+#   g++ -std=c++17 -g -fsanitize=address,undefined -Isrc -o /tmp/pe \
+#       src/patchelf.cc
+#   PATCHELF=/tmp/pe ITERS=500 tests/property-rewrite.sh
+
+PATCHELF=${PATCHELF:-../src/patchelf}
+CC=${CC:-cc}
+CXX=${CXX:-c++}
+ITERS=${ITERS:-25}
+SEED=${SEED:-$$}
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/patchelf-property.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# Seeded xorshift32. rnd must not run in a subshell or the state is lost, so
+# it writes the global rng and RND; callers read RND/PICK, never $(rnd).
+rng=$(( SEED & 0xffffffff )); [ "$rng" -ne 0 ] || rng=2463534242
+rnd() {
+    rng=$(( (rng ^ (rng << 13)) & 0xffffffff ))
+    rng=$(( rng ^ (rng >> 17) ))
+    rng=$(( (rng ^ (rng << 5)) & 0xffffffff ))
+    RND=$rng
+}
+pick() { rnd; _i=$(( RND % $# + 1 )); eval "PICK=\${$_i}"; }
+rand_layout() {
+    pick "-Wl,-z,max-page-size=0x1000" "-Wl,-z,max-page-size=0x4000" \
+         "-Wl,-z,max-page-size=0x200000" "-Wl,-z,separate-code" \
+         "-Wl,-z,noseparate-code" "-Wl,-z,relro,-z,now" "-Wl,-z,norelro" \
+         "-Wl,--hash-style=sysv" "-Wl,--hash-style=gnu" "-Wl,--hash-style=both" \
+         "-Wl,--build-id=none" "-Wl,--build-id=sha1" "-Wl,-z,noexecstack" \
+         "-Wl,--enable-new-dtags" "-Wl,--disable-new-dtags" \
+         "-Wl,-z,pack-relative-relocs" "-fcf-protection=full" ""
+}
+
+# Long string for rpath/needed edits.
+# It grows .dynstr and relocates sections to the end of the file.
+# That is the invasive rewrite path, not an edit that fits in slack.
+LONG=$(printf '%0200d' 0 | tr 0 r)
+
+# Stronger oracle than "exit 0", to catch corruption that still runs.
+# Deps resolve via LD_LIBRARY_PATH, so rpath edits don't change findability.
+# Binding is eager and loader warnings are on.
+# The exact output is required.
+run_app() { # $1=binary $2=libdir -> 0 iff it ran cleanly and printed 42
+    ( cd / || exit 1
+      err=$(LD_LIBRARY_PATH="$2" LD_BIND_NOW=1 LD_WARN=1 \
+            timeout 10 "$1" 2>"$WORK/run.err"); rc=$?
+      [ "$rc" -eq 0 ] && [ "$err" = 42 ] && [ ! -s "$WORK/run.err" ] )
+}
+
+# Versioned symbol: main gets a .gnu.version_r entry naming libdep's soname.
+# replace-needed/soname must rewrite that entry.
+# TLS plus a constructor add PT_TLS and init-array structure to keep consistent.
+cat > "$WORK/dep.c" <<'EOF'
+static __thread int tls_counter;
+__attribute__((constructor)) static void init(void) { tls_counter++; }
+int dep_value(void) { return 42 + tls_counter - tls_counter; }
+EOF
+cat > "$WORK/dep.map" <<'EOF'
+LIBDEP_1.0 { global: dep_value; local: *; };
+EOF
+# The address table makes relative relocations.
+# With -z pack-relative-relocs they become a DT_RELR/.relr.dyn section.
+# patchelf has no RELR-specific code, so it must survive a generic relocate.
+cat > "$WORK/main.c" <<'EOF'
+#include <stdio.h>
+int dep_value(void);
+int main(void);
+static void *const reltab[] = { (void *)dep_value, (void *)main, (void *)reltab };
+int main(void) { if (!reltab[2]) return 1; printf("%d", dep_value()); return 0; }
+EOF
+# C++ variant: adds .eh_frame_hdr/PT_GNU_EH_FRAME, global ctors and versioned
+# libstdc++ deps. Throwing then catching forces an unwind, so a corrupted
+# .eh_frame_hdr aborts instead of printing 42 -- something "runs OK" misses.
+cat > "$WORK/main.cpp" <<'EOF'
+#include <cstdio>
+extern "C" int dep_value();
+int main() { int r = 0; try { throw dep_value(); } catch (int v) { r = v; } printf("%d", r); return 0; }
+EOF
+have_cxx=""; if command -v "$CXX" >/dev/null; then have_cxx=1; fi
+
+# Different linkers lay binaries out differently and have triggered distinct
+# patchelf bugs (e.g. lld's .init/PHT placement). Use whichever exist;
+# "default" means no -fuse-ld flag.
+linkers=default
+for ld in bfd gold lld mold; do
+    echo 'int main(void){return 0;}' \
+        | "$CC" -fuse-ld="$ld" -xc - -o "$WORK/ldtest" 2>/dev/null \
+        && linkers="$linkers $ld"
+done
+
+# The dependency is fixed, so build it once; only the app varies per case.
+"$CC" -O0 -shared -fPIC -Wl,-soname,libdep.so.0 \
+    -Wl,--version-script="$WORK/dep.map" \
+    -o "$WORK/libdep.so.0" "$WORK/dep.c" || { echo "cannot build dep"; exit 77; }
+
+echo "seed=$SEED iters=$ITERS linkers='$linkers' work=$WORK"
+# Count tested cases toward ITERS and retry skips (a linker may reject a layout
+# option, e.g. gold and -z separate-code). Cap attempts so it can't loop.
+fails=0 skipped=0 tested=0 attempt=0
+while [ "$tested" -lt "$ITERS" ] && [ "$attempt" -lt "$((ITERS * 20))" ]; do
+    attempt=$((attempt + 1)); it=$attempt
+    d="$WORK/c$it"; mkdir -p "$d"
+    pick "-pie -fPIE" "-no-pie -fno-pie"; pie=$PICK
+    rand_layout; lo1=$PICK; rand_layout; lo2=$PICK
+
+    cp "$WORK/libdep.so.0" "$d/libdep.so.0"
+    ln -sf libdep.so.0 "$d/libdep.so"
+    cp "$WORK/libdep.so.0" "$d/libextra.so.0"   # resolvable target for add-needed
+    comp=$CC src=$WORK/main.c
+    rnd; [ -n "$have_cxx" ] && [ "$(( RND % 2 ))" -eq 0 ] && comp=$CXX src=$WORK/main.cpp
+    # shellcheck disable=SC2086  # word splitting of linker list is intended
+    pick $linkers; ld=$PICK; ldf=""; [ "$ld" = default ] || ldf="-fuse-ld=$ld"
+    # shellcheck disable=SC2086  # word splitting of flag lists is intended
+    if ! "$comp" -O0 $pie $lo1 $lo2 $ldf -o "$d/app" "$src" \
+            -L"$d" -ldep -Wl,-rpath,"$d" 2>/dev/null; then
+        skipped=$((skipped + 1)); continue
+    fi
+
+    # Run with the binary's own runpath added, so rpath edits exercise the
+    # rewrite without making toolchain libs (libgcc_s, libstdc++) unfindable.
+    origrun=$($PATCHELF --print-rpath "$d/app" 2>/dev/null || true)
+    libpath="$d${origrun:+:$origrun}"
+
+    if ! run_app "$d/app" "$libpath"; then
+        skipped=$((skipped + 1)); continue
+    fi
+
+    # Self-extracting archives and signatures append data past the ELF.
+    # patchelf relocates sections to EOF, so this is a distinct path.
+    # The payload need not stay at EOF, but its bytes must survive.
+    # Count the marker now and re-check after the ops.
+    trailer="" tcount=0
+    rnd; if [ "$(( RND % 2 ))" -eq 0 ]; then
+        yes PROPTRAILER | head -c 65536 >> "$d/app"
+        trailer=1; tcount=$(grep -ac PROPTRAILER "$d/app")
+    fi
+
+    interp=$($PATCHELF --print-interpreter "$d/app" 2>/dev/null || true)
+    dep=libdep.so.0          # current DT_NEEDED name we control
+    log="$d/ops.log"; : > "$log"
+    rnd; nops=$(( RND % 6 + 1 )); broke=""; o=0
+    while [ "$o" -lt "$nops" ]; do
+        o=$((o + 1))
+        rnd; case $(( RND % 8 )) in
+        0) pick /lib/x "/lib/$LONG"; set -- --set-rpath "$PICK:$d" ;;
+        1) pick /lib/y "/lib/$LONG"; set -- --add-rpath "$PICK" ;;
+        2) set -- --remove-rpath ;;
+        3) set -- --shrink-rpath ;;
+        4) [ -n "$interp" ] || continue; set -- --set-interpreter "$interp" ;;
+        5)  pick libextra.so.0 "lib$LONG.so.0"; nm=$PICK
+            [ "$nm" = libextra.so.0 ] || ln -sf libextra.so.0 "$d/$nm"
+            set -- --add-needed "$nm" ;;
+        6) set -- --remove-needed libextra.so.0 ;;
+        7)  # "dep.so.0" is a suffix of the original; it hits the .dynstr
+            # suffix-reuse path. The others force a fresh (long) string.
+            pick "dep.so.0" "renamed.so.0" "lib$LONG.so.0"; new=$PICK
+            [ "$new" != "$dep" ] || continue
+            ln -sf libdep.so.0 "$d/$new"
+            set -- --replace-needed "$dep" "$new"; dep="$new" ;;
+        esac
+        echo "$*" >> "$log"
+        if ! $PATCHELF "$@" "$d/app" 2>>"$log"; then
+            broke="patchelf failed: $*"; break
+        fi
+        if ! run_app "$d/app" "$libpath"; then
+            broke="binary broken after: $*"; break
+        fi
+        if [ -n "$trailer" ] && [ "$(grep -ac PROPTRAILER "$d/app")" -lt "$tcount" ]; then
+            broke="trailing payload lost after: $*"; break
+        fi
+    done
+
+    if [ -n "$broke" ]; then
+        fails=$((fails + 1))
+        echo "FAIL case $it: $broke"
+        echo "  comp=$comp ld=$ld pie=$pie layout='$lo1 $lo2'"
+        echo "  op sequence:"; sed 's/^/    /' "$log"
+        keep="property-fail-$SEED-$it"; rm -rf "$keep"; cp -r "$d" "$keep"
+        echo "  artifacts: $keep"
+    fi
+    tested=$((tested + 1))
+done
+
+echo "done: $((tested - fails)) passed, $fails failed, $skipped skipped, $attempt attempts (seed=$SEED)"
+[ "$fails" -eq 0 ]

--- a/tests/remove-rld-map-rel.sh
+++ b/tests/remove-rld-map-rel.sh
@@ -1,0 +1,52 @@
+#! /bin/sh -e
+# Regression: removing a .dynamic entry (--remove-rpath / --remove-needed)
+# compacts the array in place, which moves DT_MIPS_RLD_MAP_REL to an earlier
+# slot. Its value is an offset *relative to the slot's own address*, so it must
+# be adjusted by the distance moved or the dynamic linker writes the debug
+# pointer into whatever happens to precede .rld_map.
+#
+# The check is the loader's invariant
+#   .dynamic_addr + index(tag) * sizeof(Elf_Dyn) + d_val == .rld_map_addr
+# computed from readelf, so it runs on any host without executing the binary.
+
+SCRATCH=scratch/$(basename "$0" .sh)
+READELF=${READELF:-readelf}
+PATCHELF=../src/patchelf
+
+if ! ${READELF} -d main | grep -q MIPS_RLD_MAP_REL; then
+    echo "No MIPS_RLD_MAP_REL dynamic section entry, skipping"
+    exit 77
+fi
+
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}"
+
+# One readelf pass; awk emits a shell arithmetic expression so hex stays in
+# the shell (POSIX awk has no hex literals). The -S index "[ N]"/"[NN]" is
+# stripped first so the section name is always $1.
+check() {
+    off=$(( $(${READELF} -SWd "$1" | sed 's/^ *\[[ 0-9]*\]//' | awk '
+        $1 == ".dynamic"   { dyn = $3; ent = $6 }
+        $1 == ".rld_map"   { rld = $3 }
+        /^ 0x/             { i++ }
+        /MIPS_RLD_MAP_REL/ { slot = i-1; val = $NF }
+        END { printf "0x%s + %d * 0x%s + %s - 0x%s\n", dyn, slot, ent, val, rld }') ))
+    [ "$off" -eq 0 ] && return
+    echo "$1: DT_MIPS_RLD_MAP_REL misses .rld_map by $off bytes"
+    return 1
+}
+
+# Sanity: the freshly linked binary satisfies the invariant.
+check main
+
+# DT_NEEDED entries come first, so removing one shifts every later entry down.
+cp main "${SCRATCH}/needed"
+${PATCHELF} --remove-needed libfoo.so "${SCRATCH}/needed"
+check "${SCRATCH}/needed"
+
+# Same for --remove-rpath; only meaningful when the toolchain emitted one.
+if [ -n "$(${PATCHELF} --print-rpath main)" ]; then
+    cp main "${SCRATCH}/rpath"
+    ${PATCHELF} --remove-rpath "${SCRATCH}/rpath"
+    check "${SCRATCH}/rpath"
+fi


### PR DESCRIPTION
The existing fuzz harness feeds mostly-invalid bytes looking for crashes. This adds the complementary property: applying patchelf operations to a valid, runnable binary must leave it runnable.

It builds dynamic executables with randomized layout/link options (page size, separate-code, relro, hash style, build-id, PIE), applies a random sequence of rpath/needed/interpreter/replace-needed operations, and runs the binary after each one. Dependencies are resolved via LD_LIBRARY_PATH so rpath edits exercise the section rewrite without changing whether libs are findable, and each case verifies the freshly built binary runs before patching so a build hiccup is skipped rather than reported as a regression.