### PR TITLE
Record empty/relative run-path entries as resolution cache search hints

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -2345,9 +2345,8 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
     }
 
     /* Resolve each soname against the run path, first match wins (as the
-       loader does). Directories containing dynamic-string tokens or a
-       glibc-hwcaps subdirectory can't be resolved at patch time, so record
-       them as a search hint for the loader instead of an exact path. */
+       loader does). Components that only resolve at run time are recorded as a
+       search hint for the loader instead of an exact path (see loop below). */
     std::map<std::string, std::string> cache;
     auto addEntry = [&](const std::string & lib, const std::string & resolved) {
         auto & entry = cache[lib];
@@ -2362,13 +2361,17 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
         return lib.find('/') == std::string::npos;
     };
     for (const auto & dir : runPath) {
-        /* The loader reads an empty run-path component as the current working
-           directory, which is meaningless to bake in at patch time. */
-        if (dir.empty())
-            continue;
-        const bool hasToken = dir.find('$') != std::string::npos;
-        const bool hasHwcaps = access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0;
-        if (hasToken || hasHwcaps) {
+        /* An empty or relative component resolves against the process's
+           current directory at run time, so it can't be baked into an exact
+           path here. Dynamic-string tokens and glibc-hwcaps directories
+           likewise must be probed by the loader. All are recorded as a search
+           hint in run-path order, so a later exact entry can't bypass this
+           earlier search position. */
+        const bool runtimeOnly = dir.empty() || dir[0] != '/';
+        const bool hasToken = !runtimeOnly && dir.find('$') != std::string::npos;
+        const bool hasHwcaps = !runtimeOnly && !hasToken
+            && access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0;
+        if (runtimeOnly || hasToken || hasHwcaps) {
             const std::string hint = "?" + dir;
             for (const auto & lib : needed)
                 if (isSearched(lib))

--- a/tests/build-resolution-cache-search-hint.sh
+++ b/tests/build-resolution-cache-search-hint.sh
@@ -53,4 +53,35 @@ if echo "$d" | grep -qF "=$(pwd)/${SCRATCH}/hw/libfoo.so"; then
     exit 1
 fi
 
+# An empty run-path component (the caller's current directory at run time)
+# only resolves at run time; it must become a bare "?" hint, kept in run-path
+# order, so the later exact libs entry cannot bypass that search position.
+cp main "${SCRATCH}/main-cwd"
+${PATCHELF} --set-rpath ":$(pwd)/${SCRATCH}/libs" "${SCRATCH}/main-cwd"
+${PATCHELF} --build-resolution-cache "${SCRATCH}/main-cwd"
+
+d=$(descriptor "${SCRATCH}/main-cwd")
+echo "$d"
+if ! echo "$d" | grep -qF "?:=$(pwd)/${SCRATCH}/libs/libfoo.so"; then
+    echo "FAIL: empty run-path component was not recorded as a '?' hint before the exact entry"
+    exit 1
+fi
+
+# A relative component would otherwise be probed against patchelf's own
+# working directory and could be baked in as a bogus relative "=" path.
+cp main "${SCRATCH}/main-rel"
+${PATCHELF} --set-rpath "relative/dir:$(pwd)/${SCRATCH}/libs" "${SCRATCH}/main-rel"
+${PATCHELF} --build-resolution-cache "${SCRATCH}/main-rel"
+
+d=$(descriptor "${SCRATCH}/main-rel")
+echo "$d"
+if ! echo "$d" | grep -qF "?relative/dir:=$(pwd)/${SCRATCH}/libs/libfoo.so"; then
+    echo "FAIL: relative run-path component was not recorded as a '?' search hint"
+    exit 1
+fi
+if echo "$d" | grep -qF "=relative/dir/libfoo.so"; then
+    echo "FAIL: relative run-path component was wrongly baked into an '=' path"
+    exit 1
+fi
+
 echo "PASS"


### PR DESCRIPTION
`buildResolutionCache()` mishandled two kinds of run-path components that only resolve at run time:

**Empty components were dropped.** An RPATH like `:/opt/libs` means: search the process's current working directory first, then `/opt/libs`. Skipping the empty component left only the exact entry `=/opt/libs/libfoo.so` in the cache, so a loader consuming the cache would load straight from `/opt/libs` even when a `libfoo.so` in the CWD should have won by search order. Cached and uncached resolution could disagree.

**Relative components were probed against patchelf's own working directory.** A component like `relative/dir` could get baked in as a bogus exact entry `=relative/dir/libfoo.so`, resolved against whatever directory patchelf happened to run in rather than the process CWD at run time.

Both are now recorded as `?` search hints in run-path order, alongside the existing dynamic string token and glibc-hwcaps cases. The loader keeps probing those positions itself before trusting any later exact entry, so cached resolution stays semantically identical to a plain run-path walk.

Includes regression tests for both cases in `tests/build-resolution-cache-search-hint.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
