### PR TITLE
Record more run-path entries as resolution cache search hints

### DIFF
--- a/patchelf.1
+++ b/patchelf.1
@@ -108,9 +108,10 @@ and records the result in a \fB.note.nixos.ldcache\fR note, so that a loader
 which understands the note can skip the run-path search at startup. Directories
 that cannot be resolved ahead of time (empty or relative components, those
 containing dynamic-string tokens such as \fB$ORIGIN\fR or a \fBglibc-hwcaps\fR
-subdirectory, and directories that do not exist at patch time) are stored as a
-search hint instead of an exact path. The cache is built once from an unpatched
-binary; this option cannot be combined with \fB--force-rpath\fR.
+subdirectory, and paths that cannot be searched at patch time because they are
+missing, not a directory, or not accessible) are stored as a search hint
+instead of an exact path. The cache is built once from an unpatched binary;
+this option cannot be combined with \fB--force-rpath\fR.
 
 .IP "--no-sort"
 Do not sort program headers or section headers.  This is useful when

--- a/patchelf.1
+++ b/patchelf.1
@@ -106,8 +106,9 @@ default library search paths.
 Resolves each DT_NEEDED dependency against the object's run path at patch time
 and records the result in a \fB.note.nixos.ldcache\fR note, so that a loader
 which understands the note can skip the run-path search at startup. Directories
-that cannot be resolved ahead of time (those containing dynamic-string tokens
-such as \fB$ORIGIN\fR, or a \fBglibc-hwcaps\fR subdirectory) are stored as a
+that cannot be resolved ahead of time (empty or relative components, those
+containing dynamic-string tokens such as \fB$ORIGIN\fR or a \fBglibc-hwcaps\fR
+subdirectory, and directories that do not exist at patch time) are stored as a
 search hint instead of an exact path. The cache is built once from an unpatched
 binary; this option cannot be combined with \fB--force-rpath\fR.
 

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -2379,10 +2379,13 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
         /* Dynamic-string tokens like $ORIGIN are expanded by the loader. */
         if (dir.find('$') != std::string::npos)
             return true;
-        /* An absolute directory absent at patch time may be populated at run
+        /* An absolute path that is missing, a non-directory placeholder, or
+           without search permission may be populated or accessible at run
            time (e.g. /run/opengl-driver/lib on NixOS, which never exists
            inside the build sandbox). */
-        if (access(dir.c_str(), F_OK) != 0)
+        struct stat st;
+        if (stat(dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)
+            || access(dir.c_str(), X_OK) != 0)
             return true;
         /* A glibc-hwcaps subdirectory makes the loader probe
            hardware-specific paths under this directory. */

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -78,7 +78,10 @@ static int forcedPageSize = -1;
 #define EM_LOONGARCH    258
 #endif
 
-[[nodiscard]] static std::vector<std::string> splitColonDelimitedString(std::string_view s)
+/* Leading and middle empty components are always kept; a trailing one is
+   dropped unless keepTrailingEmpty is set (run-path semantics read a
+   trailing ':' as a final current-directory search position). */
+[[nodiscard]] static std::vector<std::string> splitColonDelimitedString(std::string_view s, bool keepTrailingEmpty = false)
 {
     std::vector<std::string> parts;
 
@@ -88,7 +91,7 @@ static int forcedPageSize = -1;
         s = s.substr(pos + 1);
     }
 
-    if (!s.empty())
+    if (keepTrailingEmpty || !s.empty())
         parts.emplace_back(s);
 
     return parts;
@@ -2337,8 +2340,11 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
     }
     /* DT_RUNPATH takes precedence over DT_RPATH, as in the loader. */
     const char * runPathStr = dtRunPath ? dtRunPath : dtRPath;
-    std::vector<std::string> runPath =
-        runPathStr ? splitColonDelimitedString(runPathStr) : std::vector<std::string>{};
+    /* Trailing empty components are search positions like any other; an
+       entirely empty run-path string still means no search path. */
+    std::vector<std::string> runPath = runPathStr && *runPathStr
+        ? splitColonDelimitedString(runPathStr, /* keepTrailingEmpty */ true)
+        : std::vector<std::string>{};
     if (needed.empty() || runPath.empty()) {
         failIfStale();
         fprintf(stderr, "warning: --build-resolution-cache: no DT_NEEDED entries or run path to resolve; no cache written\n");

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -78,9 +78,8 @@ static int forcedPageSize = -1;
 #define EM_LOONGARCH    258
 #endif
 
-/* Leading and middle empty components are always kept; a trailing one is
-   dropped unless keepTrailingEmpty is set (run-path semantics read a
-   trailing ':' as a final current-directory search position). */
+/* A trailing ':' is a final current-directory search position under run-path
+   semantics, kept only when keepTrailingEmpty is set. */
 [[nodiscard]] static std::vector<std::string> splitColonDelimitedString(std::string_view s, bool keepTrailingEmpty = false)
 {
     std::vector<std::string> parts;
@@ -2230,9 +2229,7 @@ void ElfFile<ElfFileParamNames>::addDebugTag()
    patch in Nixpkgs that reads it; keep them in sync. The descriptor is a
    sequence of NUL-terminated (needed, path-list) string pairs, where each
    path-list entry is "=<absolute-path>" for a directly resolved library or
-   "?<dir>" for a directory the loader must still search itself (dynamic
-   string tokens, glibc-hwcaps directories, and components that only
-   resolve or exist at run time). */
+   "?<dir>" for a directory the loader must still search itself. */
 static const char ldCacheNoteName[] = "NixOS";
 static const char ldCacheSectionName[] = ".note.nixos.ldcache";
 static constexpr uint32_t NT_NIXOS_LD_CACHE = 0x63a86cb6;
@@ -2340,8 +2337,7 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
     }
     /* DT_RUNPATH takes precedence over DT_RPATH, as in the loader. */
     const char * runPathStr = dtRunPath ? dtRunPath : dtRPath;
-    /* Trailing empty components are search positions like any other; an
-       entirely empty run-path string still means no search path. */
+    /* Keep a trailing empty component; an empty run-path string has none. */
     std::vector<std::string> runPath = runPathStr && *runPathStr
         ? splitColonDelimitedString(runPathStr, /* keepTrailingEmpty */ true)
         : std::vector<std::string>{};
@@ -2353,8 +2349,7 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
 
     /* Resolve each soname against the run path, first match wins (as the
        loader does). Components that only resolve at run time are recorded as a
-       search hint for the loader instead of an exact path (see
-       needsSearchHint below). */
+       search hint instead of an exact path. */
     std::map<std::string, std::string> cache;
     auto addEntry = [&](const std::string & lib, const std::string & resolved) {
         auto & entry = cache[lib];
@@ -2368,27 +2363,21 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
     const auto isSearched = [](const std::string & lib) {
         return lib.find('/') == std::string::npos;
     };
-    /* A component gets a search hint when it can't be exhaustively searched
-       at patch time. Hints keep their run-path position, so a later exact
-       entry can't bypass an earlier search position. */
+    /* A component that can't be exhaustively searched at patch time gets a
+       hint keeping its run-path position, so a later exact entry can't bypass
+       it. This covers empty/relative components and dynamic-string tokens the
+       loader expands, absolute paths that are missing or unsearchable at patch
+       time but may appear at run time (e.g. /run/opengl-driver/lib on NixOS),
+       and glibc-hwcaps directories the loader probes for. */
     const auto needsSearchHint = [](const std::string & dir) {
-        /* An empty or relative component resolves against the process's
-           current directory at run time. */
         if (dir.empty() || dir[0] != '/')
             return true;
-        /* Dynamic-string tokens like $ORIGIN are expanded by the loader. */
         if (dir.find('$') != std::string::npos)
             return true;
-        /* An absolute path that is missing, a non-directory placeholder, or
-           without search permission may be populated or accessible at run
-           time (e.g. /run/opengl-driver/lib on NixOS, which never exists
-           inside the build sandbox). */
         struct stat st;
         if (stat(dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)
             || access(dir.c_str(), X_OK) != 0)
             return true;
-        /* A glibc-hwcaps subdirectory makes the loader probe
-           hardware-specific paths under this directory. */
         return access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0;
     };
     for (const auto & dir : runPath) {

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -2227,8 +2227,9 @@ void ElfFile<ElfFileParamNames>::addDebugTag()
    patch in Nixpkgs that reads it; keep them in sync. The descriptor is a
    sequence of NUL-terminated (needed, path-list) string pairs, where each
    path-list entry is "=<absolute-path>" for a directly resolved library or
-   "?<dir>" for a directory the loader must still search itself (used for
-   $ORIGIN-style and glibc-hwcaps directories). */
+   "?<dir>" for a directory the loader must still search itself (dynamic
+   string tokens, glibc-hwcaps directories, and components that only
+   resolve or exist at run time). */
 static const char ldCacheNoteName[] = "NixOS";
 static const char ldCacheSectionName[] = ".note.nixos.ldcache";
 static constexpr uint32_t NT_NIXOS_LD_CACHE = 0x63a86cb6;
@@ -2346,7 +2347,8 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
 
     /* Resolve each soname against the run path, first match wins (as the
        loader does). Components that only resolve at run time are recorded as a
-       search hint for the loader instead of an exact path (see loop below). */
+       search hint for the loader instead of an exact path (see
+       needsSearchHint below). */
     std::map<std::string, std::string> cache;
     auto addEntry = [&](const std::string & lib, const std::string & resolved) {
         auto & entry = cache[lib];
@@ -2360,18 +2362,28 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
     const auto isSearched = [](const std::string & lib) {
         return lib.find('/') == std::string::npos;
     };
-    for (const auto & dir : runPath) {
+    /* A component gets a search hint when it can't be exhaustively searched
+       at patch time. Hints keep their run-path position, so a later exact
+       entry can't bypass an earlier search position. */
+    const auto needsSearchHint = [](const std::string & dir) {
         /* An empty or relative component resolves against the process's
-           current directory at run time, so it can't be baked into an exact
-           path here. Dynamic-string tokens and glibc-hwcaps directories
-           likewise must be probed by the loader. All are recorded as a search
-           hint in run-path order, so a later exact entry can't bypass this
-           earlier search position. */
-        const bool runtimeOnly = dir.empty() || dir[0] != '/';
-        const bool hasToken = !runtimeOnly && dir.find('$') != std::string::npos;
-        const bool hasHwcaps = !runtimeOnly && !hasToken
-            && access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0;
-        if (runtimeOnly || hasToken || hasHwcaps) {
+           current directory at run time. */
+        if (dir.empty() || dir[0] != '/')
+            return true;
+        /* Dynamic-string tokens like $ORIGIN are expanded by the loader. */
+        if (dir.find('$') != std::string::npos)
+            return true;
+        /* An absolute directory absent at patch time may be populated at run
+           time (e.g. /run/opengl-driver/lib on NixOS, which never exists
+           inside the build sandbox). */
+        if (access(dir.c_str(), F_OK) != 0)
+            return true;
+        /* A glibc-hwcaps subdirectory makes the loader probe
+           hardware-specific paths under this directory. */
+        return access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0;
+    };
+    for (const auto & dir : runPath) {
+        if (needsSearchHint(dir)) {
             const std::string hint = "?" + dir;
             for (const auto & lib : needed)
                 if (isSearched(lib))

--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -2234,6 +2234,25 @@ static const char ldCacheNoteName[] = "NixOS";
 static const char ldCacheSectionName[] = ".note.nixos.ldcache";
 static constexpr uint32_t NT_NIXOS_LD_CACHE = 0x63a86cb6;
 
+/* A run-path component that can't be exhaustively searched at patch time gets
+   a hint keeping its run-path position, so a later exact entry can't bypass
+   it. This covers empty/relative components and dynamic-string tokens the
+   loader expands, absolute paths that are missing or unsearchable at patch
+   time but may appear at run time (e.g. /run/opengl-driver/lib on NixOS), and
+   glibc-hwcaps directories the loader probes for. */
+[[nodiscard]] static bool needsSearchHint(const std::string & dir)
+{
+    if (dir.empty() || dir[0] != '/')
+        return true;
+    if (dir.find('$') != std::string::npos)
+        return true;
+    struct stat st;
+    if (stat(dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)
+        || access(dir.c_str(), X_OK) != 0)
+        return true;
+    return access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0;
+}
+
 template<ElfFileParams>
 void ElfFile<ElfFileParamNames>::removeResolutionCache()
 {
@@ -2362,23 +2381,6 @@ void ElfFile<ElfFileParamNames>::buildResolutionCache()
        here. */
     const auto isSearched = [](const std::string & lib) {
         return lib.find('/') == std::string::npos;
-    };
-    /* A component that can't be exhaustively searched at patch time gets a
-       hint keeping its run-path position, so a later exact entry can't bypass
-       it. This covers empty/relative components and dynamic-string tokens the
-       loader expands, absolute paths that are missing or unsearchable at patch
-       time but may appear at run time (e.g. /run/opengl-driver/lib on NixOS),
-       and glibc-hwcaps directories the loader probes for. */
-    const auto needsSearchHint = [](const std::string & dir) {
-        if (dir.empty() || dir[0] != '/')
-            return true;
-        if (dir.find('$') != std::string::npos)
-            return true;
-        struct stat st;
-        if (stat(dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)
-            || access(dir.c_str(), X_OK) != 0)
-            return true;
-        return access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0;
     };
     for (const auto & dir : runPath) {
         if (needsSearchHint(dir)) {

--- a/tests/build-resolution-cache-search-hint.sh
+++ b/tests/build-resolution-cache-search-hint.sh
@@ -84,4 +84,12 @@ make_cached "${SCRATCH}/main-missing" "${here}/${SCRATCH}/does-not-exist:${libs}
 expect_entry "?${here}/${SCRATCH}/does-not-exist:=${libs}/libfoo.so" \
     "missing run-path directory was not recorded as a '?' hint before the exact entry"
 
+# A trailing empty run-path component ("libs:") is a CWD search position at
+# the end of the search order, just like a leading one; it must be preserved
+# as a trailing bare "?" hint after the exact entry, not silently dropped by
+# the run-path splitter.
+make_cached "${SCRATCH}/main-cwd-trailing" "${libs}:"
+expect_entry "=${libs}/libfoo.so:?" \
+    "trailing empty run-path component was not recorded as a trailing '?' hint"
+
 echo "PASS"

--- a/tests/build-resolution-cache-search-hint.sh
+++ b/tests/build-resolution-cache-search-hint.sh
@@ -92,4 +92,25 @@ make_cached "${SCRATCH}/main-cwd-trailing" "${libs}:"
 expect_entry "=${libs}/libfoo.so:?" \
     "trailing empty run-path component was not recorded as a trailing '?' hint"
 
+# A run-path entry that exists as a plain file is not a searchable directory;
+# like a missing directory, it may be a placeholder that becomes a populated
+# directory at run time, so it must keep its search position as a "?" hint
+# instead of being silently dropped.
+touch "${SCRATCH}/not-a-dir"
+make_cached "${SCRATCH}/main-notdir" "${here}/${SCRATCH}/not-a-dir:${libs}"
+expect_entry "?${here}/${SCRATCH}/not-a-dir:=${libs}/libfoo.so" \
+    "plain-file run-path entry was not recorded as a '?' hint before the exact entry"
+
+# A directory that exists but cannot be searched by the patching user may be
+# readable at run time; its position must also be kept as a "?" hint. Root
+# ignores directory permissions, so the probe behaves differently there.
+if [ "$(id -u)" != 0 ]; then
+    mkdir -p "${SCRATCH}/no-access"
+    chmod 000 "${SCRATCH}/no-access"
+    make_cached "${SCRATCH}/main-noaccess" "${here}/${SCRATCH}/no-access:${libs}"
+    chmod 700 "${SCRATCH}/no-access"
+    expect_entry "?${here}/${SCRATCH}/no-access:=${libs}/libfoo.so" \
+        "unsearchable run-path directory was not recorded as a '?' hint before the exact entry"
+fi
+
 echo "PASS"

--- a/tests/build-resolution-cache-search-hint.sh
+++ b/tests/build-resolution-cache-search-hint.sh
@@ -20,7 +20,7 @@ descriptor() {
 }
 
 # Sets the run path on a fresh copy of main, builds the cache, and leaves the
-# descriptor dump in $d for the expect_* helpers below.
+# descriptor dump in $d for the expect_* helpers.
 make_cached() {
     cp main "$1"
     ${PATCHELF} --set-rpath "$2" "$1"
@@ -51,8 +51,7 @@ expect_entry '?$ORIGIN/libs' "\$ORIGIN run path was not recorded as a '?' search
 # shellcheck disable=SC2016
 expect_no_entry '=$ORIGIN/libs' "\$ORIGIN run path was wrongly baked into an absolute '=' path"
 
-# libfoo.so is present here, so without the hwcaps guard it would resolve to an
-# absolute "=path"; the guard must force a "?" hint regardless.
+# libfoo.so is present here, so the hwcaps guard must force a "?" hint anyway.
 mkdir -p "${SCRATCH}/hw/glibc-hwcaps"
 cp libfoo.so "${SCRATCH}/hw/"
 make_cached "${SCRATCH}/main-hwcaps" "${here}/${SCRATCH}/hw"
@@ -61,49 +60,38 @@ expect_entry "?${here}/${SCRATCH}/hw" \
 expect_no_entry "=${here}/${SCRATCH}/hw/libfoo.so" \
     "library under a glibc-hwcaps dir was wrongly resolved to a path"
 
-# An empty run-path component (the caller's current directory at run time)
-# only resolves at run time; it must become a bare "?" hint, kept in run-path
-# order, so the later exact libs entry cannot bypass that search position.
+# An empty component is the run-time current directory: a bare "?" hint.
 make_cached "${SCRATCH}/main-cwd" ":${libs}"
 expect_entry "?:=${libs}/libfoo.so" \
     "empty run-path component was not recorded as a '?' hint before the exact entry"
 
-# A relative component would otherwise be probed against patchelf's own
-# working directory and could be baked in as a bogus relative "=" path.
+# A relative component must not be baked in against patchelf's own cwd.
 make_cached "${SCRATCH}/main-rel" "relative/dir:${libs}"
 expect_entry "?relative/dir:=${libs}/libfoo.so" \
     "relative run-path component was not recorded as a '?' search hint"
 expect_no_entry "=relative/dir/libfoo.so" \
     "relative run-path component was wrongly baked into an '=' path"
 
-# An absolute directory absent at patch time may be populated at run time
-# (e.g. /run/opengl-driver/lib inside a build sandbox); it must be recorded
-# as a "?" hint in run-path order, so the later exact libs entry cannot
-# bypass that search position.
+# An absent directory may be populated at run time (e.g. /run/opengl-driver/lib
+# in a build sandbox): keep it as a "?" hint.
 make_cached "${SCRATCH}/main-missing" "${here}/${SCRATCH}/does-not-exist:${libs}"
 expect_entry "?${here}/${SCRATCH}/does-not-exist:=${libs}/libfoo.so" \
     "missing run-path directory was not recorded as a '?' hint before the exact entry"
 
-# A trailing empty run-path component ("libs:") is a CWD search position at
-# the end of the search order, just like a leading one; it must be preserved
-# as a trailing bare "?" hint after the exact entry, not silently dropped by
-# the run-path splitter.
+# A trailing empty component ("libs:") is a final CWD search position: kept as
+# a trailing "?" hint, not dropped by the splitter.
 make_cached "${SCRATCH}/main-cwd-trailing" "${libs}:"
 expect_entry "=${libs}/libfoo.so:?" \
     "trailing empty run-path component was not recorded as a trailing '?' hint"
 
-# A run-path entry that exists as a plain file is not a searchable directory;
-# like a missing directory, it may be a placeholder that becomes a populated
-# directory at run time, so it must keep its search position as a "?" hint
-# instead of being silently dropped.
+# A plain-file entry is not a searchable directory; keep it as a "?" hint.
 touch "${SCRATCH}/not-a-dir"
 make_cached "${SCRATCH}/main-notdir" "${here}/${SCRATCH}/not-a-dir:${libs}"
 expect_entry "?${here}/${SCRATCH}/not-a-dir:=${libs}/libfoo.so" \
     "plain-file run-path entry was not recorded as a '?' hint before the exact entry"
 
-# A directory that exists but cannot be searched by the patching user may be
-# readable at run time; its position must also be kept as a "?" hint. Root
-# ignores directory permissions, so the probe behaves differently there.
+# A directory unsearchable by the patching user may be readable at run time:
+# keep it as a "?" hint. Skip as root, which ignores directory permissions.
 if [ "$(id -u)" != 0 ]; then
     mkdir -p "${SCRATCH}/no-access"
     chmod 000 "${SCRATCH}/no-access"

--- a/tests/build-resolution-cache-search-hint.sh
+++ b/tests/build-resolution-cache-search-hint.sh
@@ -1,7 +1,8 @@
 #! /bin/sh -e
 # Run-path entries that can't be resolved at patch time -- dynamic-string
-# tokens ($ORIGIN/$LIB/$PLATFORM) and glibc-hwcaps directories -- must be
-# recorded as "?<dir>" search hints, never as absolute "=<path>" entries.
+# tokens ($ORIGIN/$LIB/$PLATFORM), glibc-hwcaps directories, and components
+# that only resolve or exist at run time -- must be recorded as "?<dir>"
+# search hints, never as absolute "=<path>" entries.
 SCRATCH=scratch/$(basename "$0" .sh)
 READELF=${READELF:-readelf}
 PATCHELF=$(readlink -f "../src/patchelf")
@@ -11,77 +12,76 @@ mkdir -p "${SCRATCH}/libs"
 
 cp libfoo.so "${SCRATCH}/libs/"
 
+here=$(pwd)
+libs="${here}/${SCRATCH}/libs"
+
 descriptor() {
     ${READELF} -p .note.nixos.ldcache "$1"
 }
 
-cp main "${SCRATCH}/main-origin"
+# Sets the run path on a fresh copy of main, builds the cache, and leaves the
+# descriptor dump in $d for the expect_* helpers below.
+make_cached() {
+    cp main "$1"
+    ${PATCHELF} --set-rpath "$2" "$1"
+    ${PATCHELF} --build-resolution-cache "$1"
+    d=$(descriptor "$1")
+    echo "$d"
+}
+
+expect_entry() {
+    if ! echo "$d" | grep -qF "$1"; then
+        echo "FAIL: $2"
+        exit 1
+    fi
+}
+
+expect_no_entry() {
+    if echo "$d" | grep -qF "$1"; then
+        echo "FAIL: $2"
+        exit 1
+    fi
+}
+
 # $ORIGIN is a literal loader token; it must reach patchelf unexpanded.
 # shellcheck disable=SC2016
-${PATCHELF} --set-rpath '$ORIGIN/libs' "${SCRATCH}/main-origin"
-${PATCHELF} --build-resolution-cache "${SCRATCH}/main-origin"
-
-d=$(descriptor "${SCRATCH}/main-origin")
-echo "$d"
+make_cached "${SCRATCH}/main-origin" '$ORIGIN/libs'
 # shellcheck disable=SC2016
-if ! echo "$d" | grep -qF '?$ORIGIN/libs'; then
-    echo "FAIL: \$ORIGIN run path was not recorded as a '?' search hint"
-    exit 1
-fi
+expect_entry '?$ORIGIN/libs' "\$ORIGIN run path was not recorded as a '?' search hint"
 # shellcheck disable=SC2016
-if echo "$d" | grep -qF '=$ORIGIN/libs'; then
-    echo "FAIL: \$ORIGIN run path was wrongly baked into an absolute '=' path"
-    exit 1
-fi
+expect_no_entry '=$ORIGIN/libs' "\$ORIGIN run path was wrongly baked into an absolute '=' path"
 
 # libfoo.so is present here, so without the hwcaps guard it would resolve to an
 # absolute "=path"; the guard must force a "?" hint regardless.
 mkdir -p "${SCRATCH}/hw/glibc-hwcaps"
 cp libfoo.so "${SCRATCH}/hw/"
-cp main "${SCRATCH}/main-hwcaps"
-${PATCHELF} --set-rpath "$(pwd)/${SCRATCH}/hw" "${SCRATCH}/main-hwcaps"
-${PATCHELF} --build-resolution-cache "${SCRATCH}/main-hwcaps"
-
-d=$(descriptor "${SCRATCH}/main-hwcaps")
-echo "$d"
-if ! echo "$d" | grep -qF "?$(pwd)/${SCRATCH}/hw"; then
-    echo "FAIL: glibc-hwcaps directory was not recorded as a '?' search hint"
-    exit 1
-fi
-if echo "$d" | grep -qF "=$(pwd)/${SCRATCH}/hw/libfoo.so"; then
-    echo "FAIL: library under a glibc-hwcaps dir was wrongly resolved to a path"
-    exit 1
-fi
+make_cached "${SCRATCH}/main-hwcaps" "${here}/${SCRATCH}/hw"
+expect_entry "?${here}/${SCRATCH}/hw" \
+    "glibc-hwcaps directory was not recorded as a '?' search hint"
+expect_no_entry "=${here}/${SCRATCH}/hw/libfoo.so" \
+    "library under a glibc-hwcaps dir was wrongly resolved to a path"
 
 # An empty run-path component (the caller's current directory at run time)
 # only resolves at run time; it must become a bare "?" hint, kept in run-path
 # order, so the later exact libs entry cannot bypass that search position.
-cp main "${SCRATCH}/main-cwd"
-${PATCHELF} --set-rpath ":$(pwd)/${SCRATCH}/libs" "${SCRATCH}/main-cwd"
-${PATCHELF} --build-resolution-cache "${SCRATCH}/main-cwd"
-
-d=$(descriptor "${SCRATCH}/main-cwd")
-echo "$d"
-if ! echo "$d" | grep -qF "?:=$(pwd)/${SCRATCH}/libs/libfoo.so"; then
-    echo "FAIL: empty run-path component was not recorded as a '?' hint before the exact entry"
-    exit 1
-fi
+make_cached "${SCRATCH}/main-cwd" ":${libs}"
+expect_entry "?:=${libs}/libfoo.so" \
+    "empty run-path component was not recorded as a '?' hint before the exact entry"
 
 # A relative component would otherwise be probed against patchelf's own
 # working directory and could be baked in as a bogus relative "=" path.
-cp main "${SCRATCH}/main-rel"
-${PATCHELF} --set-rpath "relative/dir:$(pwd)/${SCRATCH}/libs" "${SCRATCH}/main-rel"
-${PATCHELF} --build-resolution-cache "${SCRATCH}/main-rel"
+make_cached "${SCRATCH}/main-rel" "relative/dir:${libs}"
+expect_entry "?relative/dir:=${libs}/libfoo.so" \
+    "relative run-path component was not recorded as a '?' search hint"
+expect_no_entry "=relative/dir/libfoo.so" \
+    "relative run-path component was wrongly baked into an '=' path"
 
-d=$(descriptor "${SCRATCH}/main-rel")
-echo "$d"
-if ! echo "$d" | grep -qF "?relative/dir:=$(pwd)/${SCRATCH}/libs/libfoo.so"; then
-    echo "FAIL: relative run-path component was not recorded as a '?' search hint"
-    exit 1
-fi
-if echo "$d" | grep -qF "=relative/dir/libfoo.so"; then
-    echo "FAIL: relative run-path component was wrongly baked into an '=' path"
-    exit 1
-fi
+# An absolute directory absent at patch time may be populated at run time
+# (e.g. /run/opengl-driver/lib inside a build sandbox); it must be recorded
+# as a "?" hint in run-path order, so the later exact libs entry cannot
+# bypass that search position.
+make_cached "${SCRATCH}/main-missing" "${here}/${SCRATCH}/does-not-exist:${libs}"
+expect_entry "?${here}/${SCRATCH}/does-not-exist:=${libs}/libfoo.so" \
+    "missing run-path directory was not recorded as a '?' hint before the exact entry"
 
 echo "PASS"


### PR DESCRIPTION
Follow-up to #658: three more classes of run-path entries that `--build-resolution-cache` silently dropped (or worse, baked in wrongly) now keep their search position as `?` hints in the note, so a loader consuming the cache still probes them at run time before any later exact `=` entry.

- **Absolute directories absent at patch time.** These may be populated at run time, e.g. `/run/opengl-driver/lib` on NixOS, which never exists inside the build sandbox. Dropping them inverted RUNPATH precedence for the graphics-driver override: a loader consuming the note would open the store's libGL instead of the driver's.
- **Trailing empty run-path components.** `splitColonDelimitedString` drops the empty component after a final colon, so `libs:` lost its last current-directory search position. The splitter gains a `keepTrailingEmpty` switch (off by default, so `--allowed-rpath-prefixes` and `--shrink-rpath` are unchanged) that `buildResolutionCache` enables.
- **Entries unsearchable at patch time.** The missing-directory probe used `access(F_OK)`, which passes for any existing path. A run-path entry that exists as a plain file, or a directory the patching user cannot search, failed every per-lib probe and lost its position. An entry is now usable for patch-time resolution only if it stats as a directory and is searchable.

Along the way the growing classification is folded into a `needsSearchHint` predicate with sequential early returns, and the test's per-scenario boilerplate is factored into `make_cached`/`expect_entry` helpers matching `build-resolution-cache-edits.sh`.

Each case has a test asserting the hint keeps its run-path order relative to exact entries; the no-access case is skipped when running as root, which ignores directory permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
